### PR TITLE
Adding the missing linkage type - GlobalValue::WeakAnyLinkage.

### DIFF
--- a/llvm/lib/MC/RepoObjectWriter.cpp
+++ b/llvm/lib/MC/RepoObjectWriter.cpp
@@ -562,6 +562,9 @@ RepoObjectWriter::toPstoreLinkage(GlobalValue::LinkageTypes L) {
     return pstore::repo::linkage_type::external;
   case GlobalValue::LinkOnceAnyLinkage:
   case GlobalValue::LinkOnceODRLinkage:
+  // TODO: WeakAnyLinkage implements as linkonce for now to allow LLVM to build
+  // correctly. Implement support for weak linkage in the future.
+  case GlobalValue::WeakAnyLinkage:
   case GlobalValue::WeakODRLinkage:
     return pstore::repo::linkage_type::linkonce;
   case GlobalValue::PrivateLinkage:

--- a/llvm/test/Feature/Repo/repo_weak_linkage_type.ll
+++ b/llvm/test/Feature/Repo/repo_weak_linkage_type.ll
@@ -1,0 +1,11 @@
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db llc -filetype=obj -mtriple=x86_64-pc-linux-gnu-repo %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@WeakData = weak global i32 0, align 4, !repo_ticket !0
+
+!repo.tickets = !{!0}
+
+!0 = !TicketNode(name: "WeakData", digest: [16 x i8] c"W6c\E4\A2\C0\0BH\D2_\C7\E5\91\E9\13\C9", linkage: weak, pruned: false)
+


### PR DESCRIPTION
This patch will fix the bug <https://github.com/SNSystems/llvm-project-prepo/issues/10>.

However, we still need to understand/answer the following questions?

1) What are differences among the four linkage types: GlobalValue::LinkOnceAnyLinkage, GlobalValue::LinkOnceODRLinkage, GlobalValue::WeakAnyLinkage and GlobalValue::WeakODRLinkage? 
2) Are they modelling ELF-style weak/linkonce linkage? 
3) If they are modelling ELF-style weak linkage, do we need to add support for that in mcrepo (and rld)?

I have sent an email to Ben, he will help answering these questions. 
