### PR TITLE
Incorrect hash calculation for a global object (GO) with a 'weak' linkage type

### DIFF
--- a/llvm/lib/IR/RepoHashCalculator.cpp
+++ b/llvm/lib/IR/RepoHashCalculator.cpp
@@ -610,7 +610,11 @@ void VariableHashCalculator::hashVariable() {
   // Global variable is constant type. Accumulate the initial value.
   // This accumulation also cover the "llvm.global_ctors",
   // "llvm.global_dtors", "llvm.used" and "llvm.compiler.used" cases.
-  GvHash.hashConstant((Gv->hasDefinitiveInitializer())
+  // If the weak global variable is initialized to another global variable, the
+  // weak data should belong to .data section and has a XFixup to that global
+  // data. The hash value should also accumulate the initial value of the weak
+  // global value.
+  GvHash.hashConstant((Gv->hasInitializer())
                           ? Gv->getInitializer()
                           : Constant::getNullValue(Gv->getValueType()));
 }

--- a/llvm/test/Feature/Repo/repo_weak_variable_hash.ll
+++ b/llvm/test/Feature/Repo/repo_weak_variable_hash.ll
@@ -1,0 +1,11 @@
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S %s | FileCheck %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@GlobalData = external dso_local global i32, align 4
+@WeakData = weak dso_local local_unnamed_addr global i32* @GlobalData, align 8
+@Data = dso_local local_unnamed_addr global i32* null, align 8
+
+;CHECK:      !0 = !TicketNode(name: "WeakData", digest: [16 x i8]  c"{{.+}}", linkage: weak, pruned: false)
+;CHECK-NEXT: !1 = !TicketNode(name: "Data", digest: [16 x i8]  c"{{.+}}", linkage: external, pruned: false)


### PR DESCRIPTION
Corrected the hash calculation for a global variable with a 'weak' linkage type.

Fixed for bug <https://github.com/SNSystems/llvm-project-prepo/issues/11>.