### PR TITLE
Issue 19: Fixed two issues in the repo pruning pass.

### DIFF
--- a/llvm/lib/MC/RepoObjectWriter.cpp
+++ b/llvm/lib/MC/RepoObjectWriter.cpp
@@ -649,9 +649,13 @@ pstore::index::digest RepoObjectWriter::buildCompilationRecord(
   CompilationHash.update(Triple.size());
   CompilationHash.update(Triple);
 
+  // Only record all compilation members one time.
+  DenseSet<TicketNode *> SeenCompilationMembers;
   auto Tickets = Asm.getContext().getTickets();
   CompilationMembers.reserve(Tickets.size());
   for (const auto Symbol : Tickets) {
+    if (!SeenCompilationMembers.insert(Symbol).second)
+      continue;
     ticketmd::DigestType const D = Symbol->getDigest();
     // Insert this name into the module-wide string set. This set is later
     // added to the whole-program string set and the ticket name addresses

--- a/llvm/lib/Transforms/IPO/RepoPruning.cpp
+++ b/llvm/lib/Transforms/IPO/RepoPruning.cpp
@@ -12,6 +12,7 @@
 #include "pstore/core/index_types.hpp"
 #include "pstore/mcrepo/fragment.hpp"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/IR/CallSite.h"
 #include "llvm/IR/MDBuilder.h"
@@ -105,6 +106,43 @@ ticketmd::DigestType toDigestType(pstore::index::digest D) {
   return Digest;
 }
 
+static void addDependentFragments(
+    Module &M, StringSet<> &DependentFragments,
+    std::shared_ptr<const pstore::index::fragment_index> const &Fragments,
+    const pstore::database &Repository, pstore::index::digest const &Digest) {
+
+  auto It = Fragments->find(Repository, Digest);
+  assert(It != Fragments->end(Repository));
+  // Create  the dependent fragments if existing in the repository.
+  auto Fragment = pstore::repo::fragment::load(Repository, It->second);
+  if (auto Dependents =
+          Fragment->atp<pstore::repo::section_kind::dependent>()) {
+    for (pstore::typed_address<pstore::repo::compilation_member> Dependent :
+         *Dependents) {
+      auto CM = pstore::repo::compilation_member::load(Repository, Dependent);
+      StringRef MDName =
+          toStringRef(pstore::get_sstring_view(Repository, CM->name).second);
+      LLVM_DEBUG(dbgs() << "    Prunning dependent name: " << MDName << '\n');
+      auto DMD =
+          TicketNode::get(M.getContext(), MDName, toDigestType(CM->digest),
+                          toGVLinkage(CM->linkage), true);
+      // If functions 'A' and 'B' are dependent on function 'C', only add a
+      // single TicketNode of 'C' to the 'repo.tickets' in order to avoid
+      // multiple compilation_members of function 'C' in the compilation.
+      if (DependentFragments.insert(MDName).second) {
+        NamedMDNode *const NMD = M.getOrInsertNamedMetadata("repo.tickets");
+        assert(NMD && "NamedMDNode cannot be NULL!");
+        NMD->addOperand(DMD);
+        // If function 'A' is dependent on function 'B' and 'B' is dependent on
+        // function 'C', both TickeNodes of 'B' and 'C' need to be added into in
+        // the 'repo.tickets' during the pruning.
+        addDependentFragments(M, DependentFragments, Fragments, Repository,
+                              CM->digest);
+      }
+    }
+  }
+}
+
 bool RepoPruning::runOnModule(Module &M) {
   if (skipModule(M) || !isObjFormatRepo(M))
     return false;
@@ -122,11 +160,12 @@ bool RepoPruning::runOnModule(Module &M) {
   }
 
   std::map<pstore::index::digest, const GlobalObject *> ModuleFragments;
+  StringSet<> DependentFragments; // Record all dependents.
 
   // Erase the unchanged global objects.
-  auto EraseUnchangedGlobalObject = [&ModuleFragments, &Fragments, &Repository,
-                                     &M](GlobalObject &GO,
-                                         llvm::Statistic &NumGO) -> bool {
+  auto EraseUnchangedGlobalObject =
+      [&ModuleFragments, &Fragments, &Repository, &M,
+       &DependentFragments](GlobalObject &GO, llvm::Statistic &NumGO) -> bool {
     if (GO.isDeclaration() || GO.hasAvailableExternallyLinkage() ||
         !isSafeToPrune(GO))
       return false;
@@ -143,37 +182,25 @@ bool RepoPruning::runOnModule(Module &M) {
     } else {
       auto It = Fragments->find(Repository, Key);
       if (It == Fragments->end(Repository)) {
+        LLVM_DEBUG(dbgs() << "New GO name: " << GO.getName() << '\n');
         InRepository = false;
       } else {
-        // Create  the dependent fragments if existing in the repository.
-        auto Fragment = pstore::repo::fragment::load(Repository, It->second);
-        if (auto Dependents =
-                Fragment->atp<pstore::repo::section_kind::dependent>()) {
-          for (pstore::typed_address<pstore::repo::compilation_member>
-                   Dependent : *Dependents) {
-            auto CM =
-                pstore::repo::compilation_member::load(Repository, Dependent);
-            StringRef MDName = toStringRef(
-                pstore::get_sstring_view(Repository, CM->name).second);
-            auto DMD = TicketNode::get(M.getContext(), MDName,
-                                       toDigestType(CM->digest),
-                                       toGVLinkage(CM->linkage), true);
-            NamedMDNode *const NMD = M.getOrInsertNamedMetadata("repo.tickets");
-            assert(NMD && "NamedMDNode cannot be NULL!");
-            NMD->addOperand(DMD);
-          }
-        }
+        LLVM_DEBUG(dbgs() << "Prunning GO name: " << GO.getName() << '\n');
+        addDependentFragments(M, DependentFragments, Fragments, Repository,
+                              Key);
       }
     }
 
     if (!InRepository) {
       auto It = ModuleFragments.find(Key);
-      // The definition of some global objects may be discarded if not used. If
-      // a global has been pruned and its digest matches a discardable GO, a
-      // missing fragment error might be met during the assembler. To avoid this
-      // issue, this global object can't be pruned if the referenced global
-      // object is discardable.
+      // The definition of some global objects may be discarded if not used.
+      // If a global has been pruned and its digest matches a discardable GO,
+      // a missing fragment error might be met during the assembler. To avoid
+      // this issue, this global object can't be pruned if the referenced
+      // global object is discardable.
       if (It == ModuleFragments.end() || It->second->isDiscardableIfUnused()) {
+        LLVM_DEBUG(dbgs() << "Putting GO name into ModuleFragments: "
+                          << GO.getName() << '\n');
         ModuleFragments.emplace(Key, &GO);
         return false;
       }

--- a/llvm/test/Feature/Repo/repo_prunning_dependents.ll
+++ b/llvm/test/Feature/Repo/repo_prunning_dependents.ll
@@ -1,0 +1,47 @@
+; This testcase tests the program repository pruning pass.
+;
+; If function 'A' is dependent on function 'B' and 'B' is dependent
+; on function 'C', both TickeNodes of 'B' and 'C' need to be added
+; into in the 'repo.tickets' during the pruning.
+
+; The testcase includes three steps:
+; Step 1: Build the code and create the database 'clang.db' which contains all Tickets.
+; Step 2: Dump all compilation members in the database;
+; Step 3: Re-build the same IR code again.
+; Step 4: Dump all compilation members in the database again;
+; Step 5: Check that the step 2 and step 4 generate the same compilation members.
+
+; This test only works for the Debug build because the digest of A is calculated for the Debug build.
+
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db llc -mtriple="x86_64-pc-linux-gnu-repo" -filetype=obj %s -o %t
+; RUN: env REPOFILE=%t.db pstore-dump  -all-compilations %t.db > %t.log
+; RUN: env REPOFILE=%t.db clang -O3 -c --target=x86_64-pc-linux-gnu-repo -x ir %s  -o %t1
+; RUN: env REPOFILE=%t.db pstore-dump  -all-compilations %t.db > %t1.log
+; RUN: diff %t.log %t1.log
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+define i32 @A() !repo_ticket !0 {
+entry:
+  %call = call i32 @B()
+  ret i32 %call
+}
+
+define internal i32 @B() {
+entry:
+  %call = call i32 @C()
+  ret i32 %call
+}
+
+define internal i32 @C() {
+entry:
+  ret i32 1
+}
+
+
+!repo.tickets = !{!0}
+
+!0 = !TicketNode(name: "A", digest: [16 x i8] c"m\EB7\F7\055\B2\DD\D5\B3\FAX<o\E5\87", linkage: external, pruned: false)

--- a/llvm/test/Feature/Repo/repo_prunning_dependents_1.ll
+++ b/llvm/test/Feature/Repo/repo_prunning_dependents_1.ll
@@ -1,0 +1,50 @@
+; This testcase tests the program repository pruning pass.
+;
+; If functions 'A' and 'B' are both dependent on function 'C',
+; only add a single TicketNode of 'C' to the 'repo.tickets'
+; in order to avoid multiple compilation_members of function
+; 'C' in the compilation.
+
+; The testcase includes three steps:
+; Step 1: Build the code and create the database 'clang.db' which contains all Tickets.
+; Step 2: Dump all compilation members in the database;
+; Step 3: Re-build the same IR code again.
+; Step 4: Dump all compilation members in the database again;
+; Step 5: Check that the step 2 and step 4 generate the same compilation members.
+
+; This test only works for the Debug build because the digest of A is calculated for the Debug build.
+
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db llc -mtriple="x86_64-pc-linux-gnu-repo" -filetype=obj %s -o %t
+; RUN: env REPOFILE=%t.db pstore-dump  -all-compilations %t.db > %t.log
+; RUN: env REPOFILE=%t.db clang -O3 -c --target=x86_64-pc-linux-gnu-repo -x ir %s  -o %t1
+; RUN: env REPOFILE=%t.db pstore-dump  -all-compilations %t.db > %t1.log
+; RUN: diff %t.log %t1.log
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+define i32 @A() !repo_ticket !0 {
+entry:
+  %call = call i32 @C()
+  ret i32 %call
+}
+
+define i32 @B() !repo_ticket !1 {
+entry:
+  %call = call i32 @C()
+  %add = add nsw i32 %call, 1
+  ret i32 %add
+}
+
+define internal i32 @C() {
+entry:
+  ret i32 1
+}
+
+
+!repo.tickets = !{!0, !1}
+
+!0 = !TicketNode(name: "A", digest: [16 x i8] c"\04/(b\14\96%nK~\A7S]\F8\99\88", linkage: external, pruned: false)
+!1 = !TicketNode(name: "B", digest: [16 x i8] c"\DB\0F\C1\C1\E5\C2\1F\F7\FDp\10\12\8C\0A~\EA", linkage: external, pruned: false)


### PR DESCRIPTION
Fixed for the issue <https://github.com/SNSystems/llvm-project-prepo/issues/19>. Two issues have been found and fixed in the repo pruning pass.

1) If functions 'A' and 'B' are both dependent on function 'C', only add a single TicketNode of 'C' to the 'repo.tickets' in order to avoid multiple compilation_members of function 'C' in the compilation.
2) If function 'A' is dependent on function 'B' and 'B' is dependent on function 'C', both TickeNodes of 'B' and 'C' need to be added into in the 'repo.tickets' during the pruning.

