### PR TITLE
Re-generate the GV metadata after the globalopt pass if its initial value changes.

### DIFF
--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -2016,7 +2016,7 @@ static bool processInternalGlobal(
       if (isa<UndefValue>(GV->getInitializer())) {
         // Change the initial value here.
         GV->setInitializer(SOVConstant);
-        // If the buid is targeted on Repo, change the GV digest value.
+        // If the build targets the repo, change the GV digest value.
         if (IsRepo)
           calculateGlobalDigest(GV);
 
@@ -2358,7 +2358,7 @@ OptimizeGlobalVars(Module &M, TargetLibraryInfo *TLI,
         Constant *New = ConstantFoldConstant(C, DL, TLI);
         if (New && New != C) {
           GV->setInitializer(New);
-          // If the buid is targeted on Repo, change the GV digest value.
+          // If the build targets the repo, change the GV digest value.
           if (IsRepo)
             calculateGlobalDigest(GV);
         }
@@ -2424,7 +2424,7 @@ static void CommitValueTo(Constant *Val, Constant *Addr) {
   if (GlobalVariable *GV = dyn_cast<GlobalVariable>(Addr)) {
     assert(GV->hasInitializer());
     GV->setInitializer(Val);
-    // If the buid is targeted on Repo, change the GV digest value.
+    // If the build targets the repo, change the GV digest value.
     if (IsRepo)
       calculateGlobalDigest(GV);
     return;
@@ -2434,7 +2434,7 @@ static void CommitValueTo(Constant *Val, Constant *Addr) {
   GlobalVariable *GV = cast<GlobalVariable>(CE->getOperand(0));
   auto NewVal = EvaluateStoreInto(GV->getInitializer(), Val, CE, 2);
   GV->setInitializer(NewVal);
-  // If the buid is targeted on Repo, change the GV digest value.
+  // If the build targets the repo, change the GV digest value.
   if (IsRepo)
     calculateGlobalDigest(GV);
 }
@@ -2507,7 +2507,7 @@ static void BatchCommitValueTo(const DenseMap<Constant*, Constant*> &Mem) {
   for (auto GVPair : GVs) {
     assert(GVPair.first->hasInitializer());
     GVPair.first->setInitializer(GVPair.second);
-    // If the buid is targeted on Repo, change the GV digest value.
+    // If the build targets the repo, change the GV digest value.
     if (IsRepo)
       calculateGlobalDigest(GVPair.first);
   }
@@ -2537,7 +2537,7 @@ static void BatchCommitValueTo(const DenseMap<Constant*, Constant*> &Mem) {
           CurrentGV->setInitializer(ConstantArray::get(ArrTy, Elts));
         else
           CurrentGV->setInitializer(ConstantVector::get(Elts));
-        // If the buid is targeted on Repo, change the GV digest value.
+        // If the build targets the repo, change the GV digest value.
         if (IsRepo)
           calculateGlobalDigest(CurrentGV);
       }

--- a/llvm/test/Feature/Repo/Inputs/repo_GV_with_zeroinitializer.ll
+++ b/llvm/test/Feature/Repo/Inputs/repo_GV_with_zeroinitializer.ll
@@ -1,0 +1,17 @@
+target triple = "x86_64-pc-linux-gnu-repo"
+
+%"StringRef" = type { i8*, i64 }
+%"Entry" = type <{ %"StringRef", i64 }>
+
+@.str.a = private unnamed_addr constant [6 x i8] c"Hello\00", align 1
+@_a = internal global [1 x %"Entry"] zeroinitializer, align 16
+define { %"Entry"*} @_get_a() local_unnamed_addr {
+  ret { %"Entry"*} { %"Entry"* getelementptr inbounds ([1 x %"Entry"], [1 x %"Entry"]* @_a, i64 0, i64 0) }
+}
+
+@llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 65535, void ()* @_GLOBAL__sub_I_a.cpp, i8* null }]
+
+define internal void @_GLOBAL__sub_I_a.cpp() section ".text.startup" {
+  store i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str.a, i64 0, i64 0), i8** getelementptr inbounds ([1 x %"Entry"], [1 x %"Entry"]* @_a, i64 0, i64 0, i32 0, i32 0), align 16
+  ret void
+}

--- a/llvm/test/Feature/Repo/repo_pruning_GV_with_zeroinitializer.ll
+++ b/llvm/test/Feature/Repo/repo_pruning_GV_with_zeroinitializer.ll
@@ -5,8 +5,8 @@
 ; needs to be recalculated.
 
 ; The testcase includes three steps:
-; Step 1: Build the test Inputs/repo_GV_with_zeroinitializer.ll and create the database 'clang.db' which contains the Tickets.
-; Step 2: Build this file and check the function '-b' doesn't be pruned.
+; Step 1: Build the test Inputs/repo_GV_with_zeroinitializer.ll and create the database 'clang.db' which contains the compilations ('_a' and '.str.a').
+; Step 2: Build this file and check the function '_b' hasn't been pruned ('_b' and '_a' have the different digest values).
 
 ; This test only works for the Debug build because the digest of A is calculated for the Debug build.
 

--- a/llvm/test/Feature/Repo/repo_pruning_GV_with_zeroinitializer.ll
+++ b/llvm/test/Feature/Repo/repo_pruning_GV_with_zeroinitializer.ll
@@ -1,0 +1,36 @@
+; This testcase tests that hash generation for GV with zeroinitializer.
+;
+; If a global variable has zeroinitializer during the RepoMetadataGenerationPass and
+; its initial value changes after the RepoMetadataGenerationPass, the digest of GV
+; needs to be recalculated.
+
+; The testcase includes three steps:
+; Step 1: Build the test Inputs/repo_GV_with_zeroinitializer.ll and create the database 'clang.db' which contains the Tickets.
+; Step 2: Build this file and check the function '-b' doesn't be pruned.
+
+; This test only works for the Debug build because the digest of A is calculated for the Debug build.
+
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -O3 -S -mtriple=x86_64-pc-linux-gnu-repo %S/Inputs/repo_GV_with_zeroinitializer.ll  -o %t.ll
+; RUN: env REPOFILE=%t.db llc -mtriple="x86_64-pc-linux-gnu-repo" -filetype=obj %t.ll -o %t.o
+; RUN: env REPOFILE=%t.db opt -O3 -S -mtriple=x86_64-pc-linux-gnu-repo %s | FileCheck %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+%"StringRef" = type { i8*, i64 }
+%"Entry" = type <{ %"StringRef", i64 }>
+
+@.str.b = private unnamed_addr constant [7 x i8] c"World!\00", align 1
+@_b = internal global [1 x %"Entry"] zeroinitializer, align 16
+define { %"Entry"*} @_get_b() local_unnamed_addr {
+  ret { %"Entry"*} { %"Entry"* getelementptr inbounds ([1 x %"Entry"], [1 x %"Entry"]* @_b, i64 0, i64 0) }
+}
+
+@llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 65535, void ()* @_GLOBAL__sub_I_b.cpp, i8* null }]
+
+define internal void @_GLOBAL__sub_I_b.cpp() section ".text.startup" {
+  store i8* getelementptr inbounds ([7 x i8], [7 x i8]* @.str.b, i64 0, i64 0), i8** getelementptr inbounds ([1 x %"Entry"], [1 x %"Entry"]* @_b, i64 0, i64 0, i32 0, i32 0), align 16
+  ret void
+}
+
+;CHECK: !TicketNode(name: "_b", digest: [16 x i8] c"{{.+}}", linkage: internal, pruned: false)


### PR DESCRIPTION
If a global variable has zero-initializer during the RepoMetadataGenerationPass and its initial value changes after the globalopt pass, the GV's metadata needs to be re-generated.

Fix for <https://github.com/SNSystems/llvm-project-prepo/issues/25>.