### PR TITLE
Add the hash calculation of global aliases for functions.

### DIFF
--- a/llvm/lib/IR/RepoHashCalculator.cpp
+++ b/llvm/lib/IR/RepoHashCalculator.cpp
@@ -320,6 +320,11 @@ void HashCalculator::hashGlobalValue(const GlobalValue *V) {
       hashConstant(GV->getInitializer());
   }
 
+  if (auto *GA = dyn_cast<GlobalAlias>(V)) {
+    if (auto GAV = dyn_cast<GlobalValue>(GA->getAliasee()->stripPointerCasts()))
+      V = GAV;
+  }
+
   if (auto *GO = dyn_cast<GlobalObject>(V)) {
     // Push GO into the dependent list if it is not a declaration.
     if (!GO->isDeclaration())

--- a/llvm/test/Feature/Repo/Inputs/repo_shared_GOs.ll
+++ b/llvm/test/Feature/Repo/Inputs/repo_shared_GOs.ll
@@ -13,3 +13,10 @@ define void @call_foo() {
   %call = call i32 @foo()
   ret void
 }
+
+@bar = alias i32(), i32()* @Fn
+define i32 @test() {
+entry:
+  %0 = call i32() @bar()
+  ret i32 %0
+}

--- a/llvm/test/Feature/Repo/repo_hash_function_aliases.ll
+++ b/llvm/test/Feature/Repo/repo_hash_function_aliases.ll
@@ -1,0 +1,22 @@
+; Test the handling of global aliases for function.
+;
+; RUN: rm -rf %t.db
+; RUN: env REPOFILE=%t.db opt -S %S/Inputs/repo_shared_GOs.ll -o %t 2>&1
+; RUN: env REPOFILE=%t.db llc -filetype=obj %t -o /dev/null 2>&1
+; RUN: env REPOFILE=%t.db opt -S %s | FileCheck %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+define i32 @Fn() {
+entry:
+  ret i32 2
+}
+
+@bar = alias i32(), i32()* @Fn
+define i32 @test() {
+entry:
+  %0 = call i32() @bar()
+  ret i32 %0
+}
+
+;CHECK: !TicketNode(name: "test", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: false)


### PR DESCRIPTION
Currently, Repo hash calculation only considered the handling of global aliases for variables but not for functions.

Fix for <https://github.com/SNSystems/llvm-project-prepo/issues/29>.