### PR TITLE
 Add a reverse-dependency for a global variable in the Repo metadata generation pass

### DIFF
--- a/llvm/include/llvm/IR/RepoHashCalculator.h
+++ b/llvm/include/llvm/IR/RepoHashCalculator.h
@@ -177,6 +177,8 @@ public:
 
   ticketmd::DependenciesType &getDependencies() { return Dependencies; }
 
+  ticketmd::ContributionsType &getContributions() { return Contributions; }
+
 private:
   // Accumulate the hash of basicblocks, instructions and variables etc in the
   // function Fn.
@@ -184,6 +186,9 @@ private:
 
   // Hold the global object list which the function hash depenendent on.
   ticketmd::DependenciesType Dependencies;
+
+  // Hold the global variables which the function/variable hash contributed to.
+  ticketmd::ContributionsType Contributions;
 
   /// Assign serial numbers to values from the function.
   /// Explanation:
@@ -298,6 +303,19 @@ private:
 
   // Hold the function hash value.
   HashCalculator FnHash;
+
+  template <typename T>
+  void addContributionsFromCallInvoke(const T *Instruction) {
+    for (unsigned i = 0, ie = Instruction->getNumArgOperands(); i != ie; ++i) {
+      if (auto *GV = getAddressFromValue(Instruction->getArgOperand(i))) {
+        FnHash.getContributions().insert(GV);
+      }
+    }
+  }
+
+  const GlobalVariable *getAddressFromConstant(const Constant *C);
+  const GlobalVariable *getAddressFromValue(const Value *V);
+  const GlobalVariable *getStoreAddress(const StoreInst *SI);
 };
 
 /// VariableHashCalculator - Calculate the global variable hash.
@@ -345,12 +363,14 @@ struct DigestCalculator<Function> {
 };
 
 template <typename T>
-ticketmd::DigestAndDependencies calculateDigestAndDependencies(const T *GO) {
+ticketmd::DigestAndDependenciesAndContributions
+calculateDigestAndDependenciesAndContributions(const T *GO) {
   // Calculate the initial global object hash value and dependent list.
   typename DigestCalculator<T>::Calculator GOHC{GO};
   GOHC.calculateHash();
-  return std::make_pair(std::move(GOHC.getHashResult()),
-                        std::move(GOHC.hasher().getDependencies()));
+  return std::make_tuple(std::move(GOHC.getHashResult()),
+                         std::move(GOHC.hasher().getDependencies()),
+                         std::move(GOHC.hasher().getContributions()));
 }
 
 } // end namespace llvm

--- a/llvm/include/llvm/IR/RepoHashCalculator.h
+++ b/llvm/include/llvm/IR/RepoHashCalculator.h
@@ -363,14 +363,13 @@ struct DigestCalculator<Function> {
 };
 
 template <typename T>
-ticketmd::DigestAndDependenciesAndContributions
-calculateDigestAndDependenciesAndContributions(const T *GO) {
+ticketmd::GOInfo calculateDigestAndDependenciesAndContributions(const T *GO) {
   // Calculate the initial global object hash value and dependent list.
   typename DigestCalculator<T>::Calculator GOHC{GO};
   GOHC.calculateHash();
-  return std::make_tuple(std::move(GOHC.getHashResult()),
-                         std::move(GOHC.hasher().getDependencies()),
-                         std::move(GOHC.hasher().getContributions()));
+  return {std::move(GOHC.getHashResult()),
+          std::move(GOHC.hasher().getDependencies()),
+          std::move(GOHC.hasher().getContributions())};
 }
 
 } // end namespace llvm

--- a/llvm/include/llvm/IR/RepoTicket.h
+++ b/llvm/include/llvm/IR/RepoTicket.h
@@ -74,7 +74,7 @@ struct GOInfo {
 };
 using GOInfoMap = DenseMap<const GlobalObject *, GOInfo>;
 
-/// A map from a global variable (GV) to its memory dependents.
+/// A map from a global variable (GV) to the contibutions.
 using GVInfoMap = DenseMap<const GlobalVariable *, DependenciesType>;
 
 /// A tuple containing the global object information and two unsigned values

--- a/llvm/lib/IR/RepoHashCalculator.cpp
+++ b/llvm/lib/IR/RepoHashCalculator.cpp
@@ -329,7 +329,7 @@ void HashCalculator::hashGlobalValue(const GlobalValue *V) {
   if (auto *GO = dyn_cast<GlobalObject>(V)) {
     // Push GO into the dependent list if it is not a declaration.
     if (!GO->isDeclaration())
-      getDependencies().emplace_back(GO);
+      getDependencies().insert(GO);
   }
 }
 

--- a/llvm/lib/IR/RepoHashCalculator.cpp
+++ b/llvm/lib/IR/RepoHashCalculator.cpp
@@ -313,6 +313,7 @@ void HashCalculator::hashGlobalValue(const GlobalValue *V) {
   }
 
   GlobalNumbers.insert(std::make_pair(V, GlobalNumbers.size()));
+
   if (auto *GV = dyn_cast<GlobalVariable>(V)) {
     // Accumulate the initial value of global variable .
     Hash.update(HashKind::TAG_GlobalVariable);
@@ -441,6 +442,54 @@ void FunctionHashCalculator::hashDILocation(const DILocation *DL,
   }
 }
 
+const GlobalVariable *
+FunctionHashCalculator::getAddressFromConstant(const Constant *C) {
+  if (auto *GV = dyn_cast<GlobalVariable>(C)) {
+    // e.g. store i32 1, i32 * @GV
+    if (GV->hasDefinitiveInitializer()) {
+      if (auto *MemoryGV = dyn_cast<GlobalVariable>(GV->getInitializer()))
+        return getAddressFromConstant(MemoryGV);
+    }
+    return GV;
+  }
+
+  if (auto *GA = dyn_cast<GlobalAlias>(C))
+    if (GA->getAliasee() && !GA->isInterposable())
+      return getAddressFromConstant(GA->getAliasee());
+
+  // If the loaded value isn't a constant expr, we can't handle it.
+  auto *CE = dyn_cast<ConstantExpr>(C);
+  if (!CE)
+    return nullptr;
+
+  if (CE->getOpcode() == Instruction::GetElementPtr ||
+      CE->getOpcode() == Instruction::BitCast) {
+    return getAddressFromConstant(CE->getOperand(0));
+  }
+  return nullptr;
+}
+
+const GlobalVariable *
+FunctionHashCalculator::getAddressFromValue(const Value *V) {
+  if (auto *C = dyn_cast<Constant>(V)) {
+    return getAddressFromConstant(C);
+  } else if (auto *LI = dyn_cast<LoadInst>(V)) {
+    // e.g.
+    // @a = dso_local global i32 0, align 4
+    // @b = dso_local global i32 * @a, align 8
+    // %0 = load i32*, i32** @b, align 8
+    // store i32 5, i32* %0, align 4
+    auto LoadAddress = LI->getPointerOperand();
+    return getAddressFromValue(LoadAddress);
+  }
+  return nullptr;
+}
+
+const GlobalVariable *
+FunctionHashCalculator::getStoreAddress(const StoreInst *SI) {
+  return getAddressFromValue(SI->getPointerOperand());
+}
+
 /// Accumulate the instruction hash. The opcodes, type, operand types, operands
 /// value and any other factors affecting the operation must be considered.
 void FunctionHashCalculator::hashInstruction(const Instruction *V,
@@ -467,11 +516,13 @@ void FunctionHashCalculator::hashInstruction(const Instruction *V,
     update(HashKind::TAG_CallInst);
     update(CI->isTailCall());
     hashCallInvoke(CI);
+    addContributionsFromCallInvoke(CI);
     return;
   }
   if (const InvokeInst *II = dyn_cast<InvokeInst>(V)) {
     update(HashKind::TAG_InvokeInst);
     hashCallInvoke(II);
+    addContributionsFromCallInvoke(II);
     return;
   }
 
@@ -504,6 +555,9 @@ void FunctionHashCalculator::hashInstruction(const Instruction *V,
     FnHash.hashNumber(SI->getAlignment());
     FnHash.hashOrdering(SI->getOrdering());
     update(SI->getSyncScopeID());
+    if (auto *GV = getStoreAddress(SI)) {
+      FnHash.getContributions().insert(GV);
+    }
     return;
   }
   if (const CmpInst *CI = dyn_cast<CmpInst>(V)) {
@@ -601,6 +655,18 @@ void FunctionHashCalculator::hashFunction() {
 void FunctionHashCalculator::calculateHash() {
   FnHash.beginCalculate(*Fn->getParent());
   hashFunction();
+#ifndef NDEBUG
+  LLVM_DEBUG(dbgs() << "\nGO name is:" << Fn->getName()
+                    << ". Its dependencies are: ");
+  for (auto D : FnHash.getDependencies()) {
+    LLVM_DEBUG(dbgs() << D->getName() << ", ");
+  }
+  LLVM_DEBUG(dbgs() << ". Its contributions are: ");
+  for (auto C : FnHash.getContributions()) {
+    LLVM_DEBUG(dbgs() << C->getName() << ", ");
+  }
+  LLVM_DEBUG(dbgs() << "\n");
+#endif
 }
 
 /// Calculate the function hash and return the result as the words.

--- a/llvm/test/Assembler/repo-prunning.ll
+++ b/llvm/test/Assembler/repo-prunning.ll
@@ -15,24 +15,24 @@
 
 target triple = "x86_64-pc-linux-gnu-elf"
 
-;CHECK: @c = available_externally global i32 8, align 4, !repo_ticket !0
+;CHECK: @c = available_externally global i32 8, align 4
 $c = comdat any
 @c = global i32 8, align 4, comdat($c)
-;CHECK: @a = available_externally global i32 1, align 4, !repo_ticket !1
+;CHECK: @a = available_externally global i32 1, align 4
 $a = comdat exactmatch
 @a = global i32 1, align 4, comdat($a)
-;CHECK: @b = available_externally global i32 1, align 4, !repo_ticket !2
+;CHECK: @b = available_externally global i32 1, align 4
 $b = comdat largest
 @b = internal global i32 1, comdat, align 4, comdat($b)
 
-;CHECK: define available_externally i8* @me() !repo_ticket !3 {
+;CHECK: define available_externally i8* @me()
 $me = comdat noduplicates
 define linkonce_odr i8* @me() comdat($me) {
 entry:
   ret i8* bitcast (i8* ()* @me to i8*)
 }
 
-;CHECK: define available_externally i32 @foo() !repo_ticket !4 {
+;CHECK: define available_externally i32 @foo()
 define internal i32 @foo() {
 entry:
   %0 = load i32, i32* @a, align 4
@@ -44,16 +44,16 @@ entry:
   ret i32 %1
 }
 
-;CHECK: define available_externally i32 @bar() !repo_ticket !5 {
+;CHECK: define available_externally i32 @bar()
 define i32 @bar() {
 entry:
   %call = call i32 @foo()
   ret i32 %call
 }
 
-;CHECK:      !0 = !TicketNode(name: "c", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: true)
-;CHECK-NEXT: !1 = !TicketNode(name: "a", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: true)
-;CHECK-NEXT: !2 = !TicketNode(name: "b", digest: [16 x i8] c"{{.*}}", linkage: internal, pruned: true)
-;CHECK-NEXT: !3 = !TicketNode(name: "me", digest: [16 x i8] c"{{.*}}", linkage: linkonce_odr, pruned: true)
-;CHECK-NEXT: !4 = !TicketNode(name: "foo", digest: [16 x i8] c"{{.*}}", linkage: internal, pruned: true)
-;CHECK-NEXT: !5 = !TicketNode(name: "bar", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: true)
+;CHECK:      !TicketNode(name: "c", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: true)
+;CHECK: !TicketNode(name: "a", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: true)
+;CHECK: !TicketNode(name: "b", digest: [16 x i8] c"{{.*}}", linkage: internal, pruned: true)
+;CHECK: !TicketNode(name: "me", digest: [16 x i8] c"{{.*}}", linkage: linkonce_odr, pruned: true)
+;CHECK: !TicketNode(name: "foo", digest: [16 x i8] c"{{.*}}", linkage: internal, pruned: true)
+;CHECK: !TicketNode(name: "bar", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: true)

--- a/llvm/test/Feature/Repo/Inputs/repo_shared_GOs.ll
+++ b/llvm/test/Feature/Repo/Inputs/repo_shared_GOs.ll
@@ -20,3 +20,60 @@ entry:
   %0 = call i32() @bar()
   ret i32 %0
 }
+
+; uase by repo_store_GV.ll.
+@X = global i32 0
+
+define void @foov() {
+entry:
+  store i32 1, i32* @X
+  ret void
+}
+
+; uase by repo_store_getelementptr.ll.
+@xs = global [2 x i32] zeroinitializer, align 4
+
+define void @test1() {
+entry:
+  store i32 1, i32* getelementptr inbounds ([2 x i32], [2 x i32]* @xs, i64 0, i64 0)
+  ret void
+}
+
+; uase by repo_store_load.ll.
+@a = global i32 0, align 4
+@b = global i32* @a, align 8
+
+; Function Attrs: noinline nounwind optnone uwtable
+define void @test2() {
+entry:
+  %0 = load i32*, i32** @b, align 8
+  store i32 2, i32* %0, align 4
+  ret void
+}
+
+; uase by repo_store_bitcast.ll.
+%TS = type { i64* }
+%TA = type { i64 }
+
+@s = local_unnamed_addr global %TS zeroinitializer, align 8
+@gA = local_unnamed_addr global %TA* inttoptr (i64 69905 to %TA*), align 8
+
+define void @test3() {
+  %1 = load i64, i64* bitcast (%TA** @gA to i64*), align 8
+  store i64 %1, i64* bitcast (%TS* @s to i64*), align 8
+  ret void
+}
+
+; uase by repo_call_GV.ll.
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@Z = global i32 1
+define void @test4() {
+	call void @setto( i32* @Z, i32 2 )
+	ret void
+}
+
+define void @setto(i32* %P, i32 %V) {
+	store i32 %V, i32* %P
+	ret void
+}

--- a/llvm/test/Feature/Repo/Inputs/repo_shared_GOs.ll
+++ b/llvm/test/Feature/Repo/Inputs/repo_shared_GOs.ll
@@ -21,7 +21,7 @@ entry:
   ret i32 %0
 }
 
-; uase by repo_store_GV.ll.
+; use by repo_store_GV.ll.
 @X = global i32 0
 
 define void @foov() {
@@ -30,7 +30,7 @@ entry:
   ret void
 }
 
-; uase by repo_store_getelementptr.ll.
+; use by repo_store_getelementptr.ll.
 @xs = global [2 x i32] zeroinitializer, align 4
 
 define void @test1() {
@@ -39,7 +39,7 @@ entry:
   ret void
 }
 
-; uase by repo_store_load.ll.
+; use by repo_store_load.ll.
 @a = global i32 0, align 4
 @b = global i32* @a, align 8
 
@@ -51,7 +51,7 @@ entry:
   ret void
 }
 
-; uase by repo_store_bitcast.ll.
+; use by repo_store_bitcast.ll.
 %TS = type { i64* }
 %TA = type { i64 }
 
@@ -64,7 +64,7 @@ define void @test3() {
   ret void
 }
 
-; uase by repo_call_GV.ll.
+; use by repo_call_GV.ll.
 target triple = "x86_64-pc-linux-gnu-repo"
 
 @Z = global i32 1

--- a/llvm/test/Feature/Repo/repo_call_GV.ll
+++ b/llvm/test/Feature/Repo/repo_call_GV.ll
@@ -1,0 +1,21 @@
+; Test the call instruction which change the value of global variable .
+;
+; RUN: rm -rf %t.db
+; RUN: env REPOFILE=%t.db opt -S %S/Inputs/repo_shared_GOs.ll -o %t 2>&1
+; RUN: env REPOFILE=%t.db llc -filetype=obj %t -o /dev/null 2>&1
+; RUN: env REPOFILE=%t.db opt -S %s | FileCheck %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@Z = global i32 1
+define void @test4() {
+	call void @setto( i32* @Z, i32 3 )
+	ret void
+}
+
+define void @setto(i32* %P, i32 %V) {
+	store i32 %V, i32* %P
+	ret void
+}
+
+;CHECK: !TicketNode(name: "Z", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: false)

--- a/llvm/test/Feature/Repo/repo_store_GV.ll
+++ b/llvm/test/Feature/Repo/repo_store_GV.ll
@@ -1,0 +1,18 @@
+; Test the store instruction which store new value to a global variable.
+;
+; RUN: rm -rf %t.db
+; RUN: env REPOFILE=%t.db opt -S %S/Inputs/repo_shared_GOs.ll -o %t 2>&1
+; RUN: env REPOFILE=%t.db llc -filetype=obj %t -o /dev/null 2>&1
+; RUN: env REPOFILE=%t.db opt -S %s | FileCheck %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@X = global i32 0
+
+define void @foov() {
+entry:
+    store i32 2, i32* @X
+    ret void
+}
+
+;CHECK: !TicketNode(name: "X", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: false)

--- a/llvm/test/Feature/Repo/repo_store_bitcast.ll
+++ b/llvm/test/Feature/Repo/repo_store_bitcast.ll
@@ -1,0 +1,22 @@
+; Test the store instruction which store new value to a global variable using bitcase.
+;
+; RUN: rm -rf %t.db
+; RUN: env REPOFILE=%t.db opt -S %S/Inputs/repo_shared_GOs.ll -o %t 2>&1
+; RUN: env REPOFILE=%t.db llc -filetype=obj %t -o /dev/null 2>&1
+; RUN: env REPOFILE=%t.db opt -S %s | FileCheck %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+%TS = type { i64* }
+%TA = type { i64 }
+
+@s = local_unnamed_addr global %TS zeroinitializer, align 8
+@gA = local_unnamed_addr global %TA* inttoptr (i64 69925 to %TA*), align 8
+
+define void @test3() {
+  %1 = load i64, i64* bitcast (%TA** @gA to i64*), align 8
+  store i64 %1, i64* bitcast (%TS* @s to i64*), align 8
+  ret void
+}
+
+;CHECK: !TicketNode(name: "s", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: false)

--- a/llvm/test/Feature/Repo/repo_store_getelementptr.ll
+++ b/llvm/test/Feature/Repo/repo_store_getelementptr.ll
@@ -1,0 +1,18 @@
+; Test the store instruction which store new value to a global variable using getelementptr.
+;
+; RUN: rm -rf %t.db
+; RUN: env REPOFILE=%t.db opt -S %S/Inputs/repo_shared_GOs.ll -o %t 2>&1
+; RUN: env REPOFILE=%t.db llc -filetype=obj %t -o /dev/null 2>&1
+; RUN: env REPOFILE=%t.db opt -S %s | FileCheck %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@xs = global [2 x i32] zeroinitializer, align 4
+
+define void @test1() {
+entry:
+  store i32 2, i32* getelementptr inbounds ([2 x i32], [2 x i32]* @xs, i64 0, i64 0)
+  ret void
+}
+
+;CHECK: !TicketNode(name: "xs", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: false)

--- a/llvm/test/Feature/Repo/repo_store_load.ll
+++ b/llvm/test/Feature/Repo/repo_store_load.ll
@@ -1,0 +1,22 @@
+; Test the store instruction which store new value to a global variable through load instruction.
+;
+; RUN: rm -rf %t.db
+; RUN: env REPOFILE=%t.db opt -S %S/Inputs/repo_shared_GOs.ll -o %t 2>&1
+; RUN: env REPOFILE=%t.db llc -filetype=obj %t -o /dev/null 2>&1
+; RUN: env REPOFILE=%t.db opt -S %s | FileCheck %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@a = global i32 0, align 4
+@b = global i32* @a, align 8
+
+; Function Attrs: noinline nounwind optnone uwtable
+define void @test2() {
+entry:
+  %0 = load i32*, i32** @b, align 8
+  store i32 2, i32* %0, align 4
+  ret void
+}
+
+;CHECK: !TicketNode(name: "a", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: false)
+;CHECK: !TicketNode(name: "b", digest: [16 x i8] c"{{.*}}", linkage: external, pruned: false)

--- a/llvm/unittests/IR/RepoTicketMDTest.cpp
+++ b/llvm/unittests/IR/RepoTicketMDTest.cpp
@@ -48,7 +48,9 @@ protected:
   ticketmd::GOInfo getGOInfo(const GlobalType *G) {
     ticketmd::GOInfoMap InfoMap;
     return std::move(
-        ticketmd::calculateInitialDigestAndDependencies(G, InfoMap)->second);
+        ticketmd::calculateInitialDigestAndDependenciesAndContributions(G,
+                                                                        InfoMap)
+            ->second);
   }
 
   const TicketNode *getTicket(const GlobalObject *F) {

--- a/llvm/unittests/IR/RepoTicketMDTest.cpp
+++ b/llvm/unittests/IR/RepoTicketMDTest.cpp
@@ -421,9 +421,9 @@ TEST_F(SingleModule, TwolevelsCall) {
   EXPECT_EQ(QDependencies.size(), std::size_t{0})
       << "Expected that the size of q's dependent list is zero";
   EXPECT_THAT(PDependencies, ::testing::ElementsAre(Z));
-  EXPECT_THAT(FooDependencies, ::testing::ElementsAre(P, Q))
+  EXPECT_THAT(FooDependencies, ::testing::UnorderedElementsAre(P, Q))
       << "Expected foo's dependent list is {P, Q}";
-  EXPECT_THAT(BarDependencies, ::testing::ElementsAre(P, Q))
+  EXPECT_THAT(BarDependencies, ::testing::UnorderedElementsAre(P, Q))
       << "Expected bar's dependent list is {P, Q}";
 
   const auto &Result = ticketmd::generateTicketMDs(*M);


### PR DESCRIPTION
If a global variable has an initial value during the Repo metadata generation pass and its initial value changes after the global variable optimization pass, the Repo metadata generation pass need to consider this case.

To avoid teaching specific optimizations about the Repo (the pull request 26), this fix added a reverse-dependency for a global variable in the Repo metadata generation pass if it is either assigned or its address is taken. 

Fix for <https://github.com/SNSystems/llvm-project-prepo/issues/25>.