### PR TITLE
Disable LLVM dynamic library build when targeting on Repo

### DIFF
--- a/llvm/unittests/Support/CMakeLists.txt
+++ b/llvm/unittests/Support/CMakeLists.txt
@@ -88,4 +88,8 @@ set_source_files_properties(AlignOfTest.cpp PROPERTIES COMPILE_FLAGS -w)
 # ManagedStatic.cpp uses <pthread>.
 target_link_libraries(SupportTests PRIVATE LLVMTestingSupport ${LLVM_PTHREAD_LIB})
 
-add_subdirectory(DynamicLibrary)
+if(CMAKE_C_COMPILER_TARGET STREQUAL "x86_64-pc-linux-gnu-repo")
+  message (WARNING "Disabled the dynamic library build because the Repo doesn't yet support it.")
+else()
+  add_subdirectory(DynamicLibrary)
+endif()


### PR DESCRIPTION
When building LLVM targeted on Repo, the build support library fails since Repo doesn't support the dynamic library yet. We decided to temporally disable the dynamic library build and give a warning during the project generation. Once Repo supports the dynamic library, we will enable it.