### PR TITLE
Implement the Dependencies and Contribution types as a SmallVector type.

### DIFF
--- a/llvm/include/llvm/IR/RepoHashCalculator.h
+++ b/llvm/include/llvm/IR/RepoHashCalculator.h
@@ -308,7 +308,7 @@ private:
   void addContributionsFromCallInvoke(const T *Instruction) {
     for (unsigned i = 0, ie = Instruction->getNumArgOperands(); i != ie; ++i) {
       if (auto *GV = getAddressFromValue(Instruction->getArgOperand(i))) {
-        FnHash.getContributions().insert(GV);
+        FnHash.getContributions().emplace_back(GV);
       }
     }
   }

--- a/llvm/include/llvm/IR/RepoTicket.h
+++ b/llvm/include/llvm/IR/RepoTicket.h
@@ -10,7 +10,7 @@
 #ifndef LLVM_IR_REPO_TICKET_H
 #define LLVM_IR_REPO_TICKET_H
 
-#include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/GlobalObject.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/Support/MD5.h"
@@ -34,8 +34,8 @@ namespace ticketmd {
 using DigestType = MD5::MD5Result;
 static constexpr size_t DigestSize =
     std::tuple_size<decltype(DigestType::Bytes)>::value;
-using DependenciesType = SmallSet<const GlobalObject *, 1>;
-using ContributionsType = SmallSet<const GlobalVariable *, 1>;
+using DependenciesType = SmallVector<const GlobalObject *, 1>;
+using ContributionsType = SmallVector<const GlobalVariable *, 1>;
 /// Map GO to a unique number in the function call graph.
 using GOStateMap = llvm::DenseMap<const GlobalObject *, unsigned>;
 /// A pair of the global object's dependencies and a bool which is true if

--- a/llvm/lib/IR/RepoHashCalculator.cpp
+++ b/llvm/lib/IR/RepoHashCalculator.cpp
@@ -329,7 +329,7 @@ void HashCalculator::hashGlobalValue(const GlobalValue *V) {
   if (auto *GO = dyn_cast<GlobalObject>(V)) {
     // Push GO into the dependent list if it is not a declaration.
     if (!GO->isDeclaration())
-      getDependencies().insert(GO);
+      getDependencies().emplace_back(GO);
   }
 }
 
@@ -556,7 +556,7 @@ void FunctionHashCalculator::hashInstruction(const Instruction *V,
     FnHash.hashOrdering(SI->getOrdering());
     update(SI->getSyncScopeID());
     if (auto *GV = getStoreAddress(SI)) {
-      FnHash.getContributions().insert(GV);
+      FnHash.getContributions().emplace_back(GV);
     }
     return;
   }

--- a/llvm/lib/IR/RepoTicket.cpp
+++ b/llvm/lib/IR/RepoTicket.cpp
@@ -200,7 +200,7 @@ std::tuple<bool, unsigned, unsigned> generateTicketMDs(Module &M) {
     updateDigestUseCallDependencies(&GO, Hash, Visited, GOIMap, Helper);
     for (const auto GV : GOIMap[&GO].Contributions) {
       // Record GO's possible contributions.
-      GVIMap[GV].insert(&GO);
+      GVIMap[GV].emplace_back(&GO);
     }
 
     MD5::MD5Result Digest;


### PR DESCRIPTION
A repo test (llvm-project-prepo\llvm\test\Assembler\repo-prunning.ll) is not stable mentioned in the https://github.com/SNSystems/llvm-project-prepo/issues/36. 

It is caused by the types of ‘DependenciesType’ and ‘ContributionsType’. Both types are ‘SmallSet’ and the key is the pointer address of ‘GlobalObject’ or ‘GlobalVariable’. When calculating the global object hash, the order of accumulating its dependents might be different between two time builds, which results in the different hashes.

To solve the issue, implement  ‘DependenciesType’ and ‘ContributionsType’ types as 'SmallVector'.

Fix for <https://github.com/SNSystems/llvm-project-prepo/issues/36>.