### PR TITLE
Remove the duplicated entries for the dependent GOs in a compilation file.

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -875,10 +875,14 @@ static MCSectionRepo *selectRepoSectionForGlobal(MCContext &Ctx,
     // Add new created digest to the TicketNodes.
     assert(!GO->getMetadata(LLVMContext::MD_repo_ticket) &&
            "TicketNode should be NULL!");
-    MDBuilder MDB(GO->getParent()->getContext());
     auto TN =
-        MDB.createTicketNode(GO->getName(), Result.first, GO->getLinkage());
-    Ctx.addTicketNode(TN);
+        TicketNode::getIfExists(GO->getParent()->getContext(), GO->getName(),
+                                Result.first, GO->getLinkage(), true);
+    if (!TN) {
+      MDBuilder MDB(GO->getParent()->getContext());
+      TN = MDB.createTicketNode(GO->getName(), Result.first, GO->getLinkage());
+      Ctx.addTicketNode(TN);
+    }
     Sym->CorrespondingTicketNode = TN;
   }
 

--- a/llvm/test/Feature/Repo/Inputs/repo_pruning_dependent.ll
+++ b/llvm/test/Feature/Repo/Inputs/repo_pruning_dependent.ll
@@ -1,0 +1,17 @@
+target triple = "x86_64-pc-linux-gnu-repo"
+
+define i32 @A() !repo_ticket !0 {
+entry:
+  %call = call i32 @B()
+  ret i32 %call
+}
+
+define internal i32 @B() {
+entry:
+  ret i32 1
+}
+
+
+!repo.tickets = !{!0}
+
+!0 = !TicketNode(name: "A", digest: [16 x i8] c"\BC\B0\9B/\86\B8\09I\F7P\FB\1D\DD\F1Kf", linkage: external, pruned: false)

--- a/llvm/test/Feature/Repo/repo_prunning_dependents_2.ll
+++ b/llvm/test/Feature/Repo/repo_prunning_dependents_2.ll
@@ -1,0 +1,27 @@
+; This test makes sure there is no redundant dependent GOs in a compilation file.
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db llc -filetype=obj %S/Inputs/repo_pruning_dependent.ll -o %t
+; RUN: env REPOFILE=%t.db pstore-dump  -all-compilations %t.db > %t.log
+; RUN: env REPOFILE=%t.db llc -filetype=obj %s -o %t1
+; RUN: env REPOFILE=%t.db pstore-dump  -all-compilations %t.db > %t1.log
+; RUN: diff %t.log %t1.log
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+define available_externally i32 @A() !repo_ticket !0 {
+entry:
+  %call = call i32 @B()
+  ret i32 %call
+}
+
+define internal i32 @B() {
+entry:
+  ret i32 1
+}
+
+!repo.tickets = !{!0, !1, !2}
+
+!0 = !TicketNode(name: "A", digest: [16 x i8] c"\BC\B0\9B/\86\B8\09I\F7P\FB\1D\DD\F1Kf", linkage: external, pruned: true)
+!1 = !TicketNode(name: "B", digest: [16 x i8] c"q)Tf\00H\C1\8C\B7e\E8U\CF\19'y", linkage: internal, pruned: false)
+!2 = !TicketNode(name: "B", digest: [16 x i8] c"4#\0F\1D\D2KlU*\9FM\B1\11}\90\1A", linkage: internal, pruned: true)


### PR DESCRIPTION
Use the existing TicketNode for the dependent node, whose digest is generated by the backend.

This pull request fixed the issue #45 (please see the issuse for the problem analysis).