### PR TITLE
Fix a special case for using the existing TicketNode for the dependent GO.

### DIFF
--- a/llvm/lib/MC/RepoObjectWriter.cpp
+++ b/llvm/lib/MC/RepoObjectWriter.cpp
@@ -561,13 +561,15 @@ RepoObjectWriter::toPstoreLinkage(GlobalValue::LinkageTypes L) {
   case GlobalValue::ExternalLinkage:
     return pstore::repo::linkage_type::external;
   case GlobalValue::LinkOnceAnyLinkage:
+    return pstore::repo::linkage_type::link_once_any;
   case GlobalValue::LinkOnceODRLinkage:
-  // TODO: WeakAnyLinkage implements as linkonce for now to allow LLVM to build
-  // correctly. Implement support for weak linkage in the future.
+    return pstore::repo::linkage_type::link_once_odr;
   case GlobalValue::WeakAnyLinkage:
+    return pstore::repo::linkage_type::weak_any;
   case GlobalValue::WeakODRLinkage:
-    return pstore::repo::linkage_type::linkonce;
+    return pstore::repo::linkage_type::weak_odr;
   case GlobalValue::PrivateLinkage:
+    return pstore::repo::linkage_type::internal_no_symbol;
   case GlobalValue::InternalLinkage:
     return pstore::repo::linkage_type::internal;
   case GlobalValue::CommonLinkage:

--- a/llvm/lib/Transforms/IPO/RepoPruning.cpp
+++ b/llvm/lib/Transforms/IPO/RepoPruning.cpp
@@ -68,8 +68,16 @@ GlobalValue::LinkageTypes toGVLinkage(pstore::repo::linkage_type L) {
   switch (L) {
   case pstore::repo::linkage_type::external:
     return GlobalValue::ExternalLinkage;
-  case pstore::repo::linkage_type::linkonce:
+  case pstore::repo::linkage_type::link_once_any:
     return GlobalValue::LinkOnceAnyLinkage;
+  case pstore::repo::linkage_type::link_once_odr:
+    return GlobalValue::LinkOnceODRLinkage;
+  case pstore::repo::linkage_type::weak_any:
+    return GlobalValue::WeakAnyLinkage;
+  case pstore::repo::linkage_type::weak_odr:
+    return GlobalValue::WeakODRLinkage;
+  case pstore::repo::linkage_type::internal_no_symbol:
+    return GlobalValue::PrivateLinkage;
   case pstore::repo::linkage_type::internal:
     return GlobalValue::InternalLinkage;
   case pstore::repo::linkage_type::common:

--- a/llvm/test/Feature/Repo/Inputs/repo_pruning_dependent_with_private_linkage.ll
+++ b/llvm/test/Feature/Repo/Inputs/repo_pruning_dependent_with_private_linkage.ll
@@ -1,0 +1,14 @@
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@str = private unnamed_addr constant [6 x i8] c"Ipsum\00", align 1
+
+define void @g() local_unnamed_addr !repo_ticket !0 {
+entry:
+  %puts = tail call i32 @puts(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @str, i64 0, i64 0))
+  ret void
+}
+
+declare i32 @puts(i8* nocapture readonly) local_unnamed_addr
+!repo.tickets = !{!0}
+
+!0 = !TicketNode(name: "g", digest: [16 x i8] c"r\D5\E2\FD\BC\F9\97\AB\1E\03\CFr\C8\AB\A3\14", linkage: external, pruned: false)

--- a/llvm/test/Feature/Repo/repo_prunning_dependents_3.ll
+++ b/llvm/test/Feature/Repo/repo_prunning_dependents_3.ll
@@ -1,0 +1,32 @@
+; This test makes sure there is no redundant dependent str with the private linkage type in a compilation file.
+;
+; The test compiled two IR files: repo_pruning_dependent_with_private_linkage.ll and repo_prunning_dependents_3.ll and then dump all the compilations from the database.
+; There are two compilations in the database, and each compilation should only contains a `str` compilation member. Therefore, the "name:str" should appear just twice.
+;
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db llc -filetype=obj %S/Inputs/repo_pruning_dependent_with_private_linkage.ll -o %t
+; RUN: env REPOFILE=%t.db llc -filetype=obj %s -o %t1
+; RUN: env REPOFILE=%t.db pstore-dump -all-compilations %t.db | FileCheck %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@str = private unnamed_addr constant [6 x i8] c"Ipsum\00", align 1
+
+define i32 @main() local_unnamed_addr !repo_ticket !0 {
+entry:
+  %puts.i = tail call i32 @puts(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @str, i64 0, i64 0))
+  ret i32 0
+}
+
+declare i32 @puts(i8* nocapture readonly) local_unnamed_addr
+
+!repo.tickets = !{!0, !1, !2}
+
+!0 = !TicketNode(name: "main", digest: [16 x i8] c"G\A3\F3c\9D\10\142\9D\9F\89l\BCG\1DV", linkage: external, pruned: false)
+!1 = !TicketNode(name: "a", digest: [16 x i8] c"r\D5\E2\FD\BC\F9\97\AB\1E\03\CFr\C8\AB\A3\14", linkage: external, pruned: true)
+!2 = !TicketNode(name: "str", digest: [16 x i8] c"\A7\F3w\15S\7FP|b\09\FE\FCsg\9F\01", linkage: private, pruned: true)
+
+; CHECK:     name    : str
+; CHECK:     name    : str
+; CHECK-NOT: name    : str

--- a/llvm/tools/repo2obj/repo2obj.cpp
+++ b/llvm/tools/repo2obj/repo2obj.cpp
@@ -395,7 +395,8 @@ int main(int argc, char *argv[]) {
                 OutputSection<ELFT>::SectionInfo{});
 
       auto const IsLinkOnce =
-          CM.linkage == pstore::repo::linkage_type::linkonce;
+          CM.linkage == pstore::repo::linkage_type::link_once_any ||
+          CM.linkage == pstore::repo::linkage_type::link_once_odr;
 
       auto const Fragment = pstore::repo::fragment::load(Db, CM.fext);
 


### PR DESCRIPTION
Use the existing TicketNode for the dependent GO if the dependent GO satisfies the following conditions:

1. the dependent GO has the same name and digest as the TicketNode;
2. the TicketNode has an internal linkage and the dependent GO has either private or internal linkage type.

Fix for <https://github.com/SNSystems/llvm-project-prepo/issues/40>.