### PR TITLE
Fixed the incorrect output from a program due to name collisions.

### DIFF
--- a/llvm/include/llvm/IR/RepoTicket.h
+++ b/llvm/include/llvm/IR/RepoTicket.h
@@ -35,6 +35,8 @@ namespace ticketmd {
 using DigestType = MD5::MD5Result;
 static constexpr size_t DigestSize =
     std::tuple_size<decltype(DigestType::Bytes)>::value;
+static constexpr ticketmd::DigestType NullDigest{
+    std::array<uint8_t, DigestSize>{{0}}};
 using GOVec = SmallVector<const GlobalObject *, 1>;
 /// Map GO to a unique number in the function call graph.
 using GOStateMap = llvm::DenseMap<const GlobalObject *, unsigned>;

--- a/llvm/include/llvm/MC/MCRepoObjectWriter.h
+++ b/llvm/include/llvm/MC/MCRepoObjectWriter.h
@@ -36,19 +36,23 @@ struct RepoRelocationEntry {
   const MCSymbolRepo
       *OriginalSymbol;     // The original value of Symbol if we changed it.
   uint64_t OriginalAddend; // The original value of addend.
+  StringRef UsedSymbolName; // The Symbol name is used in the relocations.
 
   RepoRelocationEntry(uint64_t Offset, const MCSymbolRepo *Symbol,
                       unsigned Type, uint64_t Addend,
                       const MCSymbolRepo *OriginalSymbol,
-                      uint64_t OriginalAddend)
+                      uint64_t OriginalAddend, const StringRef UsedSymbolName)
       : Offset(Offset), Symbol(Symbol), Type(Type), Addend(Addend),
-        OriginalSymbol(OriginalSymbol), OriginalAddend(OriginalAddend) {}
+        OriginalSymbol(OriginalSymbol), OriginalAddend(OriginalAddend),
+        UsedSymbolName(UsedSymbolName) {}
 
   void print(raw_ostream &Out) const {
     Out << "Off=" << Offset << ", Sym=" << Symbol << ", Type=" << Type
         << ", Addend=" << Addend << ", OriginalSymbol=" << OriginalSymbol
-        << ", OriginalAddend=" << OriginalAddend;
+        << ", OriginalAddend=" << OriginalAddend
+        << ", UsedSymbolName=" << UsedSymbolName;
   }
+
   void dump() const { print(errs()); }
 };
 

--- a/llvm/include/llvm/MC/MCSymbolRepo.h
+++ b/llvm/include/llvm/MC/MCSymbolRepo.h
@@ -23,6 +23,23 @@ public:
 
   // A pointer to the TiketNode metadata of the corresponding GlobalObject.
   const TicketNode *CorrespondingTicketNode = nullptr;
+
+  // Get the symbol full name.
+  static const std::string getFullName(const MCContext &Ctx,
+                                       const StringRef InitialName,
+                                       const ticketmd::DigestType &Digest) {
+    std::string FullName;
+    StringRef PrivateGlobalPrefix = Ctx.getAsmInfo()->getPrivateGlobalPrefix();
+    FullName.reserve(PrivateGlobalPrefix.size() + InitialName.size() +
+                     ticketmd::DigestSize + 1);
+    FullName.append(PrivateGlobalPrefix);
+    FullName.append(InitialName);
+    if (Digest != ticketmd::NullDigest) {
+      FullName.append(".");
+      FullName.append(Digest.digest().str());
+    }
+    return FullName;
+  }
 };
 
 } // end namespace llvm

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -875,8 +875,12 @@ static MCSectionRepo *selectRepoSectionForGlobal(MCContext &Ctx,
     // Add new created digest to the TicketNodes.
     assert(!GO->getMetadata(LLVMContext::MD_repo_ticket) &&
            "TicketNode should be NULL!");
+    const std::string SymbolName = MCSymbolRepo::getFullName(
+        Ctx, GO->getName(),
+        GlobalValue::isLocalLinkage(GO->getLinkage()) ? Result.first
+                                                      : ticketmd::NullDigest);
     auto TN = TicketNode::getIfExists(
-        GO->getParent()->getContext(), GO->getName(), Result.first,
+        GO->getParent()->getContext(), std::move(SymbolName), Result.first,
         GO->getLinkage(), GO->getVisibility(), true);
     if (!TN) {
       MDBuilder MDB(GO->getParent()->getContext());

--- a/llvm/test/Assembler/repo-prunning-dependents.ll
+++ b/llvm/test/Assembler/repo-prunning-dependents.ll
@@ -28,4 +28,4 @@ entry:
 
 ;CHECK:      !TicketNode(name: "test",
 ;CHECK-NEXT: !TicketNode(name: ".input_str",
-;CHECK-NEXT: !TicketNode(name: "str",
+;CHECK-NEXT: !TicketNode(name: "str.

--- a/llvm/test/Feature/Repo/Inputs/repo_rename_GOs.c
+++ b/llvm/test/Feature/Repo/Inputs/repo_rename_GOs.c
@@ -1,0 +1,8 @@
+extern int printf (char const *,...);
+
+// Multiple function definitions with the same string
+void FUNC_NAME (void) { printf ("shared\n"); }
+
+#ifdef DEFINE_OTHER_FUNC
+void other_func (void) { printf ("unique\n"); }
+#endif

--- a/llvm/test/Feature/Repo/repo_prunning_dependents_2.ll
+++ b/llvm/test/Feature/Repo/repo_prunning_dependents_2.ll
@@ -24,4 +24,4 @@ entry:
 
 !0 = !TicketNode(name: "A", digest: [16 x i8] c"\BC\B0\9B/\86\B8\09I\F7P\FB\1D\DD\F1Kf", linkage: external, visibility: default, pruned: true)
 !1 = !TicketNode(name: "B", digest: [16 x i8] c"q)Tf\00H\C1\8C\B7e\E8U\CF\19'y", linkage: internal, visibility: default, pruned: false)
-!2 = !TicketNode(name: "B", digest: [16 x i8] c"4#\0F\1D\D2KlU*\9FM\B1\11}\90\1A", linkage: internal, visibility: default, pruned: true)
+!2 = !TicketNode(name: "B.34230f1dd24b6c552a9f4db1117d901a", digest: [16 x i8] c"4#\0F\1D\D2KlU*\9FM\B1\11}\90\1A", linkage: internal, visibility: default, pruned: true)

--- a/llvm/test/Feature/Repo/repo_prunning_dependents_3.ll
+++ b/llvm/test/Feature/Repo/repo_prunning_dependents_3.ll
@@ -25,7 +25,7 @@ declare i32 @puts(i8* nocapture readonly) local_unnamed_addr
 
 !0 = !TicketNode(name: "main", digest: [16 x i8] c"G\A3\F3c\9D\10\142\9D\9F\89l\BCG\1DV", linkage: external, visibility: default, pruned: false)
 !1 = !TicketNode(name: "a", digest: [16 x i8] c"r\D5\E2\FD\BC\F9\97\AB\1E\03\CFr\C8\AB\A3\14", linkage: external, visibility: default, pruned: true)
-!2 = !TicketNode(name: "str", digest: [16 x i8] c"\A7\F3w\15S\7FP|b\09\FE\FCsg\9F\01", linkage: private, visibility: default, pruned: true)
+!2 = !TicketNode(name: "str.a7f37715537f507c6209fefc73679f01", digest: [16 x i8] c"\A7\F3w\15S\7FP|b\09\FE\FCsg\9F\01", linkage: private, visibility: default, pruned: true)
 
 ; CHECK:     name    : str
 ; CHECK:     name    : str

--- a/llvm/test/Feature/Repo/repo_rename_GOs_runtime_test.c
+++ b/llvm/test/Feature/Repo/repo_rename_GOs_runtime_test.c
@@ -1,0 +1,26 @@
+// This test is Linux-only.
+// REQUIRES: system-linux
+
+// RUN: rm -rf %t.db
+// RUN: env REPOFILE=%t.db clang -c -DFUNC_NAME=func1 -O3 -target x86_64-pc-linux-gnu-repo %S/Inputs/repo_rename_GOs.c -o %t.o
+// RUN: env REPOFILE=%t.db repo2obj %t.o --repo %t.db -o %t.elf.o
+// RUN: env REPOFILE=%t.db clang -c -DFUNC_NAME=func2 -DDEFINE_OTHER_FUNC -o -O3 -target x86_64-pc-linux-gnu-repo %S/Inputs/repo_rename_GOs.c -o %t1.o
+// RUN: env REPOFILE=%t.db repo2obj %t1.o --repo %t.db -o %t1.elf.o
+// RUN: env REPOFILE=%t.db clang -c -o -O3 -target x86_64-pc-linux-gnu-repo %s -o %t2.o
+// RUN: env REPOFILE=%t.db repo2obj %t2.o --repo %t.db -o %t2.elf.o
+// RUN: clang -o %t.out -O3 -target x86_64-pc-linux-gnu-repo %t.elf.o %t1.elf.o %t2.elf.o
+// RUN: %t.out | FileCheck %s
+
+extern void func1(void);
+extern void other_func(void);
+extern void func2(void);
+
+int main () {
+    func1 ();
+    other_func ();
+    func2 ();
+}
+
+// CHECK: shared
+// CHECK: unique
+// CHECK: shared

--- a/llvm/test/Feature/Repo/repo_rename_dependents_with_local_linkage.ll
+++ b/llvm/test/Feature/Repo/repo_rename_dependents_with_local_linkage.ll
@@ -1,0 +1,21 @@
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -mtriple="x86_64-pc-linux-gnu-repo" -O3 -S %s | FileCheck -check-prefix=CHECK-NAME-IN-IR %s
+; RUN: env REPOFILE=%t.db opt -mtriple="x86_64-pc-linux-gnu-repo" -O3 -S %s -o %t
+; RUN: env REPOFILE=%t.db llc -mtriple="x86_64-pc-linux-gnu-repo" -filetype=obj %t
+; RUN: env REPOFILE=%t.db opt -mtriple="x86_64-pc-linux-gnu-repo" -O3 -S %s |  FileCheck -check-prefix=CHECK-NAME-IN-DATABASE %s
+
+target triple = "x86_64-pc-linux-gnu-elf"
+
+@.input_str = private unnamed_addr constant [7 x i8] c"hello\0A\00", align 1
+
+declare i32 @printf(i8* nocapture readonly, ...)
+
+define void @test() align 2 {
+entry:
+  %call = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @.input_str, i32 0, i32 0))
+  ret void
+}
+
+;CHECK-NAME-IN-IR: @str = private 
+
+;CHECK-NAME-IN-DATABASE: !TicketNode(name: "str.{{.+}}"


### PR DESCRIPTION
It is an example of the problem described in the [GO renaming proposal](https://github.com/SNSystems/llvm-project-prepo/wiki/GO-Renaming-Proposal).

Fix for <https://github.com/SNSystems/llvm-project-prepo/issues/42>.