### PR TITLE
Add elf.cmake for comparison with repo.cmake

### DIFF
--- a/llvm/utils/repo/elf.cmake
+++ b/llvm/utils/repo/elf.cmake
@@ -1,0 +1,58 @@
+#*                        *
+#*  _ __ ___ _ __   ___   *
+#* | '__/ _ \ '_ \ / _ \  *
+#* | | |  __/ |_) | (_) | *
+#* |_|  \___| .__/ \___/  *
+#*          |_|           *
+#===- elf.cmake ----------------------------------------------------------===//
+# Copyright (c) 2017-2018 by Sony Interactive Entertainment, Inc.
+# All rights reserved.
+#
+# Developed by:
+#   Toolchain Team
+#   SN Systems, Ltd.
+#   www.snsystems.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal with the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# - Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimers.
+#
+# - Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimers in the
+#   documentation and/or other materials provided with the distribution.
+#
+# - Neither the names of SN Systems Ltd., Sony Interactive Entertainment,
+#   Inc. nor the names of its contributors may be used to endorse or
+#   promote products derived from this Software without specific prior
+#   written permission.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+# ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
+#===----------------------------------------------------------------------===//
+
+set (triple "x86_64-pc-linux-gnu")
+
+# The user must specify CMAKE_C_COMPILER by giving '-DCMAKE_C_COMPILER:FILEPATH=/path/to/c/compiler' on the command line
+SET (CMAKE_C_COMPILER   "clang"  CACHE FILEPATH "Compiler")
+# The user must specify CMAKE_CXX_COMPILER by using '-DCMAKE_CXX_COMPILER:FILEPATH=/path/to/cxx/compiler' on the command line
+SET (CMAKE_CXX_COMPILER "clang++"  CACHE FILEPATH "Compiler")
+
+SET (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -fno-exceptions -fno-rtti" CACHE STRING "Default C Flags Debug")
+SET (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -fno-exceptions -fno-rtti" CACHE STRING "Default CXX Flags Debug")
+SET (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -fno-exceptions -fno-rtti" CACHE STRING "Default C Flags Release")
+SET (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -fno-exceptions -fno-rtti" CACHE STRING "Default CXX Flags Release")
+set (CMAKE_C_COMPILER_TARGET ${triple})
+set (CMAKE_CXX_COMPILER_TARGET ${triple})
+# eof: elf.cmake

--- a/llvm/utils/repo/elf.cmake
+++ b/llvm/utils/repo/elf.cmake
@@ -1,11 +1,11 @@
-#*                        *
-#*  _ __ ___ _ __   ___   *
-#* | '__/ _ \ '_ \ / _ \  *
-#* | | |  __/ |_) | (_) | *
-#* |_|  \___| .__/ \___/  *
-#*          |_|           *
-#===- elf.cmake ----------------------------------------------------------===//
-# Copyright (c) 2017-2018 by Sony Interactive Entertainment, Inc.
+#*       _  __  *
+#*   ___| |/ _| *
+#*  / _ \ | |_  *
+#* |  __/ |  _| *
+#*  \___|_|_|   *
+#*              *
+#===- elf.cmake -----------------------------------------------------------===//
+# Copyright (c) 2017-2019 by Sony Interactive Entertainment, Inc.
 # All rights reserved.
 #
 # Developed by:
@@ -55,4 +55,3 @@ SET (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -fno-exceptions -fno-rt
 SET (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -fno-exceptions -fno-rtti" CACHE STRING "Default CXX Flags Release")
 set (CMAKE_C_COMPILER_TARGET ${triple})
 set (CMAKE_CXX_COMPILER_TARGET ${triple})
-# eof: elf.cmake


### PR DESCRIPTION
Should be able to build like in https://github.com/SNSystems/llvm-project-prepo/wiki/Build-LLVM-with-the-Repo-Compiler but with elf.cmake in place of repo.cmake. This should be useful for comparing performance.