### PR TITLE
Record time trace scope for module passes

### DIFF
--- a/llvm/lib/IR/LegacyPassManager.cpp
+++ b/llvm/lib/IR/LegacyPassManager.cpp
@@ -1815,6 +1815,8 @@ MPPassManager::runOnModule(Module &M) {
     ModulePass *MP = getContainedPass(Index);
     bool LocalChanged = false;
 
+    llvm::TimeTraceScope PassScope("RunPass", MP->getPassName());
+
     dumpPassInfo(MP, EXECUTION_MSG, ON_MODULE_MSG, M.getModuleIdentifier());
     dumpRequiredSet(MP);
 


### PR DESCRIPTION
-ftime-trace wasn't recording the time for running module passes so RepoMetadataGeneration wasn't traced. This should fix this.