### PR TITLE
Adding an early return for the recursive hash calculation algorithm.

### DIFF
--- a/llvm/test/Feature/Repo/repo_GV_diff_hash.ll
+++ b/llvm/test/Feature/Repo/repo_GV_diff_hash.ll
@@ -20,11 +20,11 @@ entry:
   ret i32 2
 }
 
-;CHECK: !0 = !TicketNode(name: "fp_foo", digest: [16 x i8] c"\A1N:d\80\EE\B4\81\9E\94\E5\A4-\8D\E6,", linkage: external, visibility: default, pruned: false)
-;CHECK: !1 = !TicketNode(name: "fp_bar", digest: [16 x i8] c"\EAu<\9D\84X\05\B4u'\8A\DCx<\0C:", linkage: external, visibility: default, pruned: false)
+;CHECK: !0 = !TicketNode(name: "fp_foo", digest: [16 x i8] c"\05\FC`\F48\E2\EEU\A7\C6m\0F\5C/yj", linkage: external, visibility: default, pruned: false)
+;CHECK: !1 = !TicketNode(name: "fp_bar", digest: [16 x i8] c"\E7\97\16\14^\8A\18\B1k\BA\E9c)\82\02\15", linkage: external, visibility: default, pruned: false)
 ;CHECK: !2 = !TicketNode(name: "a", digest: [16 x i8] c"\AC$P\92\CBZ\FF\00\A7\ADW\C01\BE\DB>", linkage: internal, visibility: default, pruned: false)
-;CHECK: !3 = !TicketNode(name: "vp_a", digest: [16 x i8] c"N9\06&\E1\D0\A5\B1Q\C3\B9]u\CC\CF\EE", linkage: external, visibility: default, pruned: false)
+;CHECK: !3 = !TicketNode(name: "vp_a", digest: [16 x i8] c">\D0mA\BC\0B\02cW\B4\81wD\C1=C", linkage: external, visibility: default, pruned: false)
 ;CHECK: !4 = !TicketNode(name: "b", digest: [16 x i8] c"\0C4\E57aqV\18\0Ag \11&\F5\91\AA", linkage: internal, visibility: default, pruned: false)
-;CHECK: !5 = !TicketNode(name: "vp_b", digest: [16 x i8] c"[\D1\D9\84\AA&\C7i\A8\F4\0B+{\BE\A69", linkage: external, visibility: default, pruned: false)
+;CHECK: !5 = !TicketNode(name: "vp_b", digest: [16 x i8] c"077;(\D6&bi\B2\B2_'\14{o", linkage: external, visibility: default, pruned: false)
 ;CHECK: !6 = !TicketNode(name: "foo", digest: [16 x i8] c"\10*j\F7-\D1\DB\C0uM}R\C0\E4\8A\8D", linkage: internal, visibility: default, pruned: false)
 ;CHECK: !7 = !TicketNode(name: "bar", digest: [16 x i8] c"\AF\CC*7\1A\BC\06:;\B5\94\1Al\8D\E7L", linkage: internal, visibility: default, pruned: false)

--- a/llvm/test/Feature/Repo/repo_GV_same_hash.ll
+++ b/llvm/test/Feature/Repo/repo_GV_same_hash.ll
@@ -21,11 +21,11 @@ entry:
   ret i32 1
 }
 
-;CHECK: !0 = !TicketNode(name: "fp_foo", digest: [16 x i8] c"\A1N:d\80\EE\B4\81\9E\94\E5\A4-\8D\E6,", linkage: external, visibility: default, pruned: false)
-;CHECK: !1 = !TicketNode(name: "fp_bar", digest: [16 x i8] c"\F0\EE\97\CA%Y\81H)8\F6\E5\B9\B2\C9\CD", linkage: external, visibility: default, pruned: false)
+;CHECK: !0 = !TicketNode(name: "fp_foo", digest: [16 x i8] c"\05\FC`\F48\E2\EEU\A7\C6m\0F\5C/yj", linkage: external, visibility: default, pruned: false)
+;CHECK: !1 = !TicketNode(name: "fp_bar", digest: [16 x i8] c"\DAhfm\DEx\DA\06\7FF\86S\E4\AE\E9\FF", linkage: external, visibility: default, pruned: false)
 ;CHECK: !2 = !TicketNode(name: "a", digest: [16 x i8] c"\AC$P\92\CBZ\FF\00\A7\ADW\C01\BE\DB>", linkage: internal, visibility: default, pruned: false)
-;CHECK: !3 = !TicketNode(name: "vp_a", digest: [16 x i8] c"N9\06&\E1\D0\A5\B1Q\C3\B9]u\CC\CF\EE", linkage: external, visibility: default, pruned: false)
+;CHECK: !3 = !TicketNode(name: "vp_a", digest: [16 x i8] c">\D0mA\BC\0B\02cW\B4\81wD\C1=C", linkage: external, visibility: default, pruned: false)
 ;CHECK: !4 = !TicketNode(name: "b", digest: [16 x i8] c"\AC$P\92\CBZ\FF\00\A7\ADW\C01\BE\DB>", linkage: internal, visibility: default, pruned: false)
-;CHECK: !5 = !TicketNode(name: "vp_b", digest: [16 x i8] c"\F8\B4K\CA\C3\EAC?\D9\82\BC\15?yq}", linkage: external, visibility: default, pruned: false)
+;CHECK: !5 = !TicketNode(name: "vp_b", digest: [16 x i8] c"W\AE\A2\DBtS\1B\08\C4\82\9B\F4\80\9E~\C9", linkage: external, visibility: default, pruned: false)
 ;CHECK: !6 = !TicketNode(name: "foo", digest: [16 x i8] c"\10*j\F7-\D1\DB\C0uM}R\C0\E4\8A\8D", linkage: internal, visibility: default, pruned: false)
 ;CHECK: !7 = !TicketNode(name: "bar", digest: [16 x i8] c"\10*j\F7-\D1\DB\C0uM}R\C0\E4\8A\8D", linkage: internal, visibility: default, pruned: false)

--- a/llvm/test/Feature/Repo/repo_InsertOrExtraValueInst_hash.ll
+++ b/llvm/test/Feature/Repo/repo_InsertOrExtraValueInst_hash.ll
@@ -3,7 +3,8 @@
 ;
 ; RUN: rm -f %t.db
 ; RUN: env REPOFILE=%t.db opt -S %s -o %t
-; RUN: env REPOFILE=%t.db opt -S %t | FileCheck %s
+; RUN: env REPOFILE=%t.db llc -filetype=obj %t -o %t1
+; RUN: env REPOFILE=%t.db opt -S %s | FileCheck %s
 
 target triple = "x86_64-pc-linux-gnu-repo"
 


### PR DESCRIPTION
The current hash calculation algorithm could calculate some global objects multiple times, which is unnecessary. The detailed description is given:
https://github.com/SNSystems/llvm-project-prepo/issues/34#issuecomment-552424464

After applying this patch,

1) The RepoMetadataGenerationPass execution time (user time) of the SemaDeclAttr.cpp file has been reduced from 20.321s to 6.98s (66% improvement).
2) For the repo-project-prepo project, the Repo related passes (RepoMetadataGenerationPass and RepoPruningPass) execution time has been reduced from 1100.097s to 619.908s (44% improvement).

Fix for #34.