### PR TITLE
Fix for issue #66 (Add “function-sections” mode).

### DIFF
--- a/llvm/test/tools/repo2obj/no-subsections.ll
+++ b/llvm/test/tools/repo2obj/no-subsections.ll
@@ -1,0 +1,32 @@
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S %s -o %t.ll
+; RUN: env REPOFILE=%t.db llc --filetype=obj %t.ll -o %t.o
+; RUN: env REPOFILE=%t.db repo2obj --no-subsections -o %t.elf %t.o
+; RUN: llvm-readobj --sections  %t.elf | FileCheck %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+define void @f() {
+  call void @j()
+  ret void
+}
+; CHECK-DAG: Name: .text (
+
+define void @g() {
+  ret void
+}
+
+
+@h = global i32 1, align 4
+; CHECK-DAG: Name: .data (
+
+
+$j = comdat any
+define linkonce_odr void @j() comdat {
+  ret void
+}
+; CHECK-DAG: Name: .text.j (
+
+; CHECK-NOT: Name: .text.f (
+; CHECK-NOT: Name: .text.g (
+; CHECK-NOT: Name: .data.h (

--- a/llvm/test/tools/repo2obj/subsections.ll
+++ b/llvm/test/tools/repo2obj/subsections.ll
@@ -1,0 +1,31 @@
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S %s -o %t.ll
+; RUN: env REPOFILE=%t.db llc --filetype=obj %t.ll -o %t.o
+; RUN: env REPOFILE=%t.db repo2obj -o %t.elf %t.o
+; RUN: llvm-readobj --sections  %t.elf | FileCheck %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+define void @f() {
+  call void @j()
+  ret void
+}
+; CHECK-DAG: Name: .text.f (
+
+define void @g() {
+  ret void
+}
+; CHECK-DAG: Name: .text.g (
+
+
+@h = global i32 1, align 4
+; CHECK-DAG: Name: .data.h (
+
+
+$j = comdat any
+define linkonce_odr void @j() comdat {
+  ret void
+}
+; CHECK-DAG: Name: .text.j (
+
+


### PR DESCRIPTION
Fix for issue #66. This change implements an equivalent of the compiler’s function-sections/data-sections mode in which each function or data object occupies a section of its own. This compiler mode is often enabled by default because many ELF consumers depend on it. In our case it is enabled by default, but can be disabled with `--no-subsections`. By more closely modelling this behavior I can more accurately compare rld to existing ELF linkers.