### PR TITLE
Fixed a pruning issue for an alias case.

### DIFF
--- a/llvm/lib/Transforms/IPO/RepoMetadataGeneration.cpp
+++ b/llvm/lib/Transforms/IPO/RepoMetadataGeneration.cpp
@@ -72,6 +72,8 @@ bool RepoMetadataGeneration::runOnModule(Module &M) {
   // Enable the program repo support for alias.
   for (GlobalAlias &GA : M.aliases()) {
     if (auto *GO = GA.getBaseObject()) {
+      LLVM_DEBUG(dbgs() << "GA: " << GA.getName()
+                        << ", its base object: " << GO->getName() << '\n');
       TicketNode *TN =
           dyn_cast<TicketNode>(GO->getMetadata(LLVMContext::MD_repo_ticket));
       assert(TN && "TN should not be NULL!");

--- a/llvm/test/Feature/Repo/repo_alias_aliasOfAlias.ll
+++ b/llvm/test/Feature/Repo/repo_alias_aliasOfAlias.ll
@@ -1,0 +1,23 @@
+; Check the pruning for an alias (C) whose aliasee is another alias (B).
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -mtriple x86_64-pc-linux-gnu-repo %s -o %t
+; RUN: env REPOFILE=%t.db llc -filetype=obj %t
+; RUN: env REPOFILE=%t.db opt -S -mtriple x86_64-pc-linux-gnu-repo %s | FileCheck %s
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+
+;CHECK: declare void @A()
+@A = alias void (), void ()* @D
+
+;CHECK: declare void @B()
+@B = alias void (), bitcast (void ()* @D to void ()*)
+
+;CHECK: declare void @C()
+@C = alias void (), void ()* @B
+
+define void @D() {
+entry:
+  ret void
+}


### PR DESCRIPTION
Current pruning implementation for the alias exists an issue for the following case.

Assuming:

- the aliasee of alias 'A' is alias 'B',
- the aliasee of alias 'B' is global object 'C',
-  the global object 'C' is pruned.

The order in the alias list is 'B' and then 'A'. Since the global object 'C' is prund,
the alias 'B' is changed from definition to declaration. Then, since 'B' is changed to
declaration, the base object of the alias 'A' will be changed from 'C' to 'B'. This
will result in the backend error.

To solve the issue, the aliases' pruning is separated into two steps.
First, check whether a GlobalAlias references a pruned GO. If yes, record it.
Second, replace all recorded aliases by the declaration.

Fix for <https://github.com/SNSystems/llvm-project-prepo/issues/81>.