### PR TITLE
Fixing a VS2017 build error.

### DIFF
--- a/llvm/lib/MC/MCRepoTicketFile.cpp
+++ b/llvm/lib/MC/MCRepoTicketFile.cpp
@@ -108,7 +108,8 @@ llvm::repo::getTicketIdFromFile(StringRef TicketPath) {
   }
 
   ErrorOr<std::unique_ptr<MemoryBuffer>> MemberBufferOrErr =
-      MemoryBuffer::getOpenFile(TicketFD, TicketPath, FileSize, false);
+      MemoryBuffer::getOpenFile(sys::fs::convertFDToNativeFile(TicketFD),
+                                TicketPath, FileSize, false);
   if (!MemberBufferOrErr) {
     return MemberBufferOrErr.getError();
   }


### PR DESCRIPTION
The build failed because of the API change of function MemoryBuffer::getOpenFile.