### PR TITLE
Improve the repo metadata generation implementation by caching the hash

### DIFF
--- a/llvm/include/llvm/IR/RepoDefinition.h
+++ b/llvm/include/llvm/IR/RepoDefinition.h
@@ -48,11 +48,6 @@ void set(GlobalObject *GO, DigestType const &D);
 /// GO does not contain the RepoDefinition metadata.
 std::pair<DigestType, bool> get(const GlobalObject *GO);
 
-struct GONumber {
-  unsigned FuncNum = 0;
-  unsigned VarNum = 0;
-};
-
 /// A structure of a global object (GO) information.
 struct GOInfo {
   /// The InitialDigest is the hash of an object itself (a function or global
@@ -98,6 +93,7 @@ struct GOInfo {
 #endif
 };
 using GOInfoMap = DenseMap<const GlobalObject *, GOInfo>;
+using MemoizedHashes = llvm::DenseMap<const GlobalObject *, DigestType>;
 
 /// A structure of a global object (GO) state.
 struct GODigestState {
@@ -107,56 +103,108 @@ struct GODigestState {
   /// A reference to an object's dependencies. The GOInfo struct takes ownership
   /// of it.
   const GOVec &Dependencies;
-  /// A bool which is true if GO's hash value has been changed.
-  bool Changed;
   GODigestState() = delete;
-  GODigestState(const GOVec &Contributions, const GOVec &Dependencies,
-                bool Changed)
-      : Contributions(Contributions), Dependencies(Dependencies),
-        Changed(Changed) {}
+  GODigestState(const GOVec &Contributions, const GOVec &Dependencies)
+      : Contributions(Contributions), Dependencies(Dependencies) {}
 };
 
-/// Calculate the initial hash value, dependencies and contributions for the
-/// global object 'G'.
-/// \param G Calculated global object.
-/// \param GOI a DenseMap containing the global object information.
-///
-template <typename GlobalType>
-void calculateGOInfo(const GlobalType *G, GOInfoMap &GOI) {
-  GOInfo Result = calculateDigestAndDependenciesAndContributedToGVs(G);
-  // ContributedToGVs of an object is used to update other objects'
-  // contributions. For example, if the ContributedToGVs of function `foo`  are
-  // global variables `g` and `q`, the function `foo` is in the contributions of
-  // `g` and `q`.
-  // ContributedToGVs[`foo`] = [`g`, `q`]
-  // ====> Contributions[`g`] = [`foo`],
-  //       Contributions[`q`] = [`foo`]
-  for (auto &GO : Result.Contributions) {
-    assert(isa<GlobalVariable>(GO) &&
-           "Only global variables can have contributions!");
-    assert(isa<llvm::Function>(G) && "All contributions are functions!");
-    GOI[GO].Contributions.emplace_back(G);
-  }
-  // Update G's dependencies.
-  GOInfo &GInfo = GOI[G];
-  GInfo.InitialDigest = std::move(Result.InitialDigest);
-  GInfo.Dependencies = std::move(Result.Dependencies);
-}
+/// Helper Class for generating the hash for each global objects on the Module.
+/// Also caches hashes for previously generated global objects (GOs).
+class ModuleHashGenerator {
 
-// Create a global object information map and calculate the number of hashed
-// functions and variable  inside of the Module M.
-/// \param M Called module.
-/// \returns a pair containing a global object information map and a structure
-/// holding the number of hashed global variables and functions.
-std::pair<GOInfoMap, GONumber> calculateGONumAndGOIMap(Module &M);
+  enum class Tags : char {
+    Backref = 'R',
+    End = 'E',
+    GO = 'T',
+  };
+
+  /// A map of GO to a unique number in the dependencies graph.
+  GOStateMap Visited;
+  /// Used to keep the GO information.
+  GOInfoMap GOIMap;
+  /// Memoize GO's hash if one of the following conditions is satisfied:
+  /// 1. GO is not in a cycle/loop.
+  /// 2. GO is in a self-loop but not if there is a loop involving another
+  /// object.
+  MemoizedHashes GOHashCache;
+  /// True if the module M is changed.
+  bool Changed = false;
+
+public:
+  ModuleHashGenerator() {}
+  /// calculate the digest for all global objects inside of the Module M.
+  void digestModule(Module &M);
+
+  /// Compute the hash value for the given global object GO.
+  /// \param GO The global object.
+  /// \param UseRepoDefinitionMD true if using the digest of GO's dependencies
+  ///        stored in the RepoDefinition metadata.
+  /// \return The global object's digest value.
+  DigestType calculateDigest(const GlobalObject *GO, bool UseRepoDefinitionMD);
+
+  bool isChanged() const { return Changed; }
+
+  const GOInfoMap &getGOInfoMap() const { return GOIMap; }
+
+  const MemoizedHashes &getGOHashCache() const { return GOHashCache; }
+
+private:
+  /// Get global object hash value from memoized hashes.
+  /// \param GO The global object.
+  /// \return A tuple of global object's hash value and a bool which is true if
+  /// GO's hash is cached.
+  std::tuple<DigestType, bool> getGOHash(const GlobalObject *GO) const {
+    const auto Iter = GOHashCache.find_as(GO);
+    return (Iter != GOHashCache.end()) ? std::make_tuple(Iter->second, true)
+                                       : std::make_tuple(NullDigest, false);
+  }
+
+  /// Construct the global object information map (GOIMap) and calculate the
+  /// number of hashed functions and variables inside of the Module M.
+  void calculateGONumAndGOIMap(const Module &M);
+
+  /// Calculate the initial hash value, dependencies and contributions for the
+  /// global object 'G' and store these informaion in the GOImap.
+  /// \param G Calculated global object.
+  template <typename GlobalType> void calculateGOInfo(const GlobalType *G);
+  void calculateGOInfo(const GlobalObject *GO);
+
+  /// Accumulate the GO's digest and get its GODigestState.
+  /// \param GO Calculated global object.
+  /// \param GOHash A object that is used to calculate the GO's hash value.
+  /// \param UseRepoDefinitionMD true if using the digest of GO's dependencies
+  ///        stored in the RepoDefinition metadata.
+  /// \returns a structure containing the GO's state.
+  GODigestState accumulateGODigest(const GlobalObject *GO, MD5 &GOHash,
+                                   bool UseRepoDefinitionMD);
+
+  /// Add the initial digest of each contribution global object to GOHash.
+  void updateDigestUseContributions(MD5 &GOHash, const GOVec &Contributions);
+
+  /// Add the final digest of each dependencies global object to GOHash.
+  std::tuple<size_t, DigestType>
+  updateDigestUseDependencies(const GlobalObject *GO, MD5 &GOHash,
+                              unsigned GODepth, const GOVec &Dependencies,
+                              bool UseRepoDefinitionMD);
+
+  /// Update the digest of an invidual GO incorporating the hashes of all its
+  /// dependencies and contributions.
+  /// \param GO The global object whose digest is to be computed.
+  /// \param UseRepoDefinitionMD true if using the digest of GO's dependencies
+  ///        stored in the RepoDefinition metadata.
+  /// \returns a tuple containing 1) the depth of the path that we've traversed
+  ///          (or max if it reaches the end of the path). and 2) the GO's
+  ///         digest.
+  std::tuple<size_t, DigestType>
+  updateDigestUseDependenciesAndContributions(const GlobalObject *GO,
+                                              bool UseRepoDefinitionMD);
+};
 
 /// Compute the hash value and set the RepoDefinition metadata for all global
 /// objects inside of the Module M.
 /// \param M Called module.
-/// \returns a tuple containing a global object information map which include if
-/// the module M has been changed, and two unsigned values which are the number
-/// of global variables and functions respectively.
-std::tuple<bool, unsigned, unsigned> generateRepoDefinitions(Module &M);
+/// \return a bool which is true if the module M has been changed.
+bool generateRepoDefinitions(Module &M);
 
 /// Compute the hash value for the given global object GO.
 /// \param GO The global object.

--- a/llvm/include/llvm/IR/RepoHashCalculator.h
+++ b/llvm/include/llvm/IR/RepoHashCalculator.h
@@ -178,9 +178,7 @@ public:
 
   repodefinition::GOVec &getDependencies() { return Dependencies; }
 
-  repodefinition::GOVec &getContributedToGVs() {
-    return ContributedToGVs;
-  }
+  repodefinition::GOVec &getContributedToGVs() { return ContributedToGVs; }
 
 private:
   // Accumulate the hash of basicblocks, instructions and variables etc in the

--- a/llvm/lib/Transforms/IPO/RepoMetadataGeneration.cpp
+++ b/llvm/lib/Transforms/IPO/RepoMetadataGeneration.cpp
@@ -27,8 +27,6 @@ using namespace llvm;
 
 #define DEBUG_TYPE "prepo"
 
-STATISTIC(NumFunctions, "Number of functions hashed");
-STATISTIC(NumVariables, "Number of variables hashed");
 STATISTIC(NumAliases, "Number of aliases hashed");
 
 namespace {
@@ -67,8 +65,6 @@ bool RepoMetadataGeneration::runOnModule(Module &M) {
     return false;
 
   auto Result = repodefinition::generateRepoDefinitions(M);
-  NumVariables += std::get<1>(Result);
-  NumFunctions += std::get<2>(Result);
 
   // Enable the program repo support for alias.
   for (GlobalAlias &GA : M.aliases()) {
@@ -88,10 +84,5 @@ bool RepoMetadataGeneration::runOnModule(Module &M) {
     }
   }
 
-  LLVM_DEBUG(dbgs() << "Size of module: " << M.size() << '\n');
-  LLVM_DEBUG(dbgs() << "Number of hashed functions: " << NumFunctions << '\n');
-  LLVM_DEBUG(dbgs() << "Number of hashed variables: " << NumVariables << '\n');
-  LLVM_DEBUG(dbgs() << "Number of hashed aliases: " << NumAliases << '\n');
-
-  return std::get<0>(Result);
+  return Result;
 }

--- a/llvm/lib/Transforms/IPO/RepoPruning.cpp
+++ b/llvm/lib/Transforms/IPO/RepoPruning.cpp
@@ -367,10 +367,5 @@ bool RepoPruning::runOnModule(Module &M) {
     delete A;
   }
 
-  LLVM_DEBUG(dbgs() << "Size of module: " << M.size() << '\n');
-  LLVM_DEBUG(dbgs() << "Number of removed functions: " << NumFunctions << '\n');
-  LLVM_DEBUG(dbgs() << "Number of removed variables: " << NumVariables << '\n');
-  LLVM_DEBUG(dbgs() << "Number of removed aliases: " << NumAliases << '\n');
-
   return IsPruned;
 }

--- a/llvm/test/Feature/Repo/repo_hash_hybrid.ll
+++ b/llvm/test/Feature/Repo/repo_hash_hybrid.ll
@@ -1,0 +1,85 @@
+; Check that the GOs' hash caculation with a graph of the form:
+;
+; digraph G {
+;   a -> b -> c -> b;
+;   a -> d -> e;
+;   d -> f;
+; }
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -stats -debug-only prepo -debug-only prepo-digest -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-elf"
+
+define void @B() {
+entry:
+  call void @C()
+  ret void
+}
+
+define void @C() {
+entry:
+  call void @B()
+  ret void
+}
+
+define i32 @E() {
+entry:
+  ret i32 1
+}
+
+define i32 @F() {
+entry:
+  ret i32 2
+}
+
+define i32 @D() {
+entry:
+  %call = call i32 @E()
+  %call1 = call i32 @F()
+  %add = add nsw i32 %call, %call1
+  ret i32 %add
+}
+
+define i32 @A() #0 {
+entry:
+  call void @B()
+  %call = call i32 @D()
+  ret i32 %call
+}
+
+;CHECK: Computing hash for "B" (#0)
+;CHECK: Computing hash for "C" (#1)
+;CHECK: Computing hash for "B" (#2)
+;CHECK: Hashing back reference to #0
+;CHECK-NOT: Recording result for "B"
+;CHECK: Computing hash for "C" (#0)
+;CHECK: Computing hash for "B" (#1)
+;CHECK: Computing hash for "C" (#2)
+;CHECK: Hashing back reference to #0
+;CHECK-NOT: Recording result for "C"
+;CHECK: Computing hash for "E" (#0)
+;CHECK: Recording result for "E"
+;CHECK: Computing hash for "F" (#0)
+;CHECK: Recording result for "F"
+;CHECK: Computing hash for "D" (#0)
+;CHECK: Computing hash for "E" (#1)
+;CHECK: Returning pre-computed hash for "E"
+;CHECK: Computing hash for "F" (#1)
+;CHECK: Returning pre-computed hash for "F"
+;CHECK: Recording result for "D"
+;CHECK: Computing hash for "A" (#0)
+;CHECK: Computing hash for "B" (#1)
+;CHECK: Computing hash for "C" (#2)
+;CHECK: Computing hash for "B" (#3)
+;CHECK: Hashing back reference to #1
+;CHECK: Computing hash for "D" (#3)
+;CHECK: Returning pre-computed hash for "D"
+;CHECK: Recording result for "A"
+;
+;CHECK:      6 prepo-digest - Number of functions hashed
+;CHECK-NEXT: 4 prepo-digest - Number of memoized hashes
+;CHECK-NEXT: 7 prepo-digest - Visited times of memoized hashes
+;CHECK-NEXT: 6 prepo-digest - Visited times of unmemoized hashes

--- a/llvm/test/Feature/Repo/repo_hash_loop.ll
+++ b/llvm/test/Feature/Repo/repo_hash_loop.ll
@@ -1,0 +1,54 @@
+; Check that the GOs' hash caculation with a graph of the form:
+;
+; digraph G {
+;   c -> a -> b -> a;
+; }
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -stats -debug-only prepo -debug-only prepo-digest -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-elf"
+
+define void @A() {
+entry:
+  call void @B()
+  ret void
+}
+
+define void @B() {
+entry:
+  call void @A()
+  ret void
+}
+
+define void @C() {
+entry:
+  call void @A()
+  ret void
+}
+
+;CHECK: Computing hash for "A" (#0)
+;CHECK: Computing hash for "B" (#1)
+;CHECK: Computing hash for "A" (#2)
+;CHECK-NOT: Returning pre-computed hash for "A"
+;CHECK: Hashing back reference to #0
+;CHECK-NOT: Recording result for "A"
+;CHECK: Computing hash for "B" (#0)
+;CHECK: Computing hash for "A" (#1)
+;CHECK: Computing hash for "B" (#2)
+;CHECK-NOT: Returning pre-computed hash for "B"
+;CHECK: Hashing back reference to #0
+;CHECK-NOT: Recording result for "B"
+;CHECK: Computing hash for "C" (#0)
+;CHECK: Computing hash for "A" (#1)
+;CHECK: Computing hash for "B" (#2)
+;CHECK: Computing hash for "A" (#3)
+;CHECK: Hashing back reference to #1
+;CHECK: Recording result for "C"
+;
+;CHECK:      3 prepo-digest - Number of functions hashed
+;CHECK-NEXT: 1 prepo-digest - Number of memoized hashes
+;CHECK-NEXT: 1 prepo-digest - Visited times of memoized hashes
+;CHECK-NEXT: 6 prepo-digest - Visited times of unmemoized hashes

--- a/llvm/test/Feature/Repo/repo_hash_self_loop.ll
+++ b/llvm/test/Feature/Repo/repo_hash_self_loop.ll
@@ -1,0 +1,39 @@
+; Check that the GOs' hash caculation with a graph of the form:
+;
+; digraph G {
+;   a -> b -> b;
+; }
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -stats -debug-only prepo -debug-only prepo-digest -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-elf"
+
+; Function Attrs: noinline nounwind optnone uwtable
+define void @B() {
+entry:
+  call void @B()
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define void @A() {
+entry:
+  call void @B()
+  ret void
+}
+
+;CHECK: Computing hash for "B" (#0)
+;CHECK: Computing hash for "B" (#1)
+;CHECK: Hashing back reference to #0
+;CHECK: Recording result for "B"
+;CHECK: Computing hash for "A" (#0)
+;CHECK: Computing hash for "B" (#1)
+;CHECK: Returning pre-computed hash for "B"
+;CHECK: Recording result for "A"
+;
+;CHECK:      2 prepo-digest - Number of functions hashed
+;CHECK-NEXT: 2 prepo-digest - Number of memoized hashes
+;CHECK-NEXT: 3 prepo-digest - Visited times of memoized hashes

--- a/llvm/test/Feature/Repo/repo_hash_simple_case.ll
+++ b/llvm/test/Feature/Repo/repo_hash_simple_case.ll
@@ -1,0 +1,46 @@
+; Check that the GOs' hash caculation with a graph of the form:
+;
+; digraph G {
+;   c -> a;
+;   c -> b;
+; }
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -stats -debug-only prepo -debug-only prepo-digest -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-elf"
+
+define i32 @A() {
+entry:
+  ret i32 1
+}
+
+define i32 @B() {
+entry:
+  ret i32 2
+}
+
+define i32 @C() {
+entry:
+  %call = call i32 @A()
+  %call1 = call i32 @B()
+  %add = add nsw i32 %call, %call1
+  ret i32 %add
+}
+
+;CHECK: Computing hash for "A" (#0)
+;CHECK: Recording result for "A"
+;CHECK: Computing hash for "B" (#0)
+;CHECK: Recording result for "B"
+;CHECK: Computing hash for "C" (#0)
+;CHECK: Computing hash for "A" (#1)
+;CHECK: Returning pre-computed hash for "A"
+;CHECK: Computing hash for "B" (#1)
+;CHECK: Returning pre-computed hash for "B"
+;CHECK: Recording result for "C"
+;
+;CHECK:      3 prepo-digest - Number of functions hashed
+;CHECK-NEXT: 3 prepo-digest - Number of memoized hashes
+;CHECK-NEXT: 5 prepo-digest - Visited times of memoized hashes


### PR DESCRIPTION
Two ways to improve the RepoMetadataGenerationPass execution time:

1) Separating the ‘visited’ table for the two directions. In other words, the contributions get a visited map and the dependencies get a separate map. This will stop the algorithm from a) thinking that it’s detecting lots of loops and b) accumulating unnecessary successors.
2) Caching the digests of each possible GOs to avoid the recalculation. It will give the further performance benefits.

The upstream LLVM+Clang is used as an application to check the performance. The performance improvement is summarised:
1) After applying the patch 1), the LLVM backend time for the first time build changed from 10269.5s to 9395.5s (8.5%improvement). The backend time for the second time build changed from 1913.5s to 1013.0s (47.06% improvement).
2) After applying the patch 2), the LLVM backend time for the first time build changed from 9395.5s to 9072.5s (further 34.38 %improvement). The backend time for the second time build changed from 1013.0s to 791.0s (further 21.91% improvement).

The RepoMetadataGenerationPass execution time (user time) of the SemaDeclAttr.cpp file has been reduced from 52,384.825ms to 5,092.376ms (90.28% improvement).

Fix for <https://github.com/SNSystems/llvm-project-prepo/issues/34>