### PR TITLE
Improve performance of repo2obj

### DIFF
--- a/llvm/tools/repo2obj/R2OELFStringTable.h
+++ b/llvm/tools/repo2obj/R2OELFStringTable.h
@@ -50,7 +50,8 @@ public:
 
 private:
   pstore::database const &Db_;
-  std::map<pstore::shared_sstring_view, pstore::raw_sstring_view> Storage_;
+  std::unordered_map<pstore::shared_sstring_view, pstore::raw_sstring_view>
+      Storage_;
 };
 
 class StringTable {

--- a/llvm/tools/repo2obj/R2OELFSymbolTable.h
+++ b/llvm/tools/repo2obj/R2OELFSymbolTable.h
@@ -16,7 +16,7 @@
 #include "R2OELFStringTable.h"
 #include "WriteHelpers.h"
 
-#include <map>
+#include <unordered_map>
 
 template <typename ELFT> class OutputSection;
 
@@ -153,7 +153,7 @@ private:
   Value *insertSymbol(pstore::indirect_string const &Name,
                       llvm::Optional<SymbolTarget> const &Target);
 
-  std::map<pstore::indirect_string, Value> SymbolMap_;
+  std::unordered_map<pstore::indirect_string, Value> SymbolMap_;
   StringTable &Strings_;
 };
 


### PR DESCRIPTION
pstore makes it extremely fast to compare strings for equality: they're stored in a set meaning that two strings with the same address are equal. Lexicographical comparison OTOH requires the strings to be loaded and compared code-unit by code-unit.

Previously the code used `map<>` which relies on `std::less<>` (lexiographical order). This change switches to `unordered_map<>` so that (once hashed) we only need equality.

Note that I’m not using LLVM’s `DenseMap<>` because I don’t currently have specializations of `DenseMapInfo<>` for either `pstore::shared_sstring_view` or `pstore::indirect_string` (the key’s of the two maps being changed here). That could happen in a future commit.

This change alters the ELF file that the tool produces. I’ve verified that a small program build with the repo compiler, and linked with a conventional link still works.