### PR TITLE
Splitting the loop into two separated loops.

### DIFF
--- a/llvm/include/llvm/IR/RepoTicket.h
+++ b/llvm/include/llvm/IR/RepoTicket.h
@@ -135,6 +135,9 @@ void calculateGOInfo(const GlobalType *G, GOInfoMap &GOI) {
   // ====> Contributions[`g`] = [`foo`],
   //       Contributions[`q`] = [`foo`]
   for (auto &GO : Result.Contributions) {
+    assert(isa<GlobalVariable>(GO) &&
+           "Only global variables can have contributions!");
+    assert(isa<llvm::Function>(G) && "All contributions are functions!");
     GOI[GO].Contributions.emplace_back(G);
   }
   // Update G's dependencies.


### PR DESCRIPTION
The current hash calculation algorithm is relatively slow, which is caused by the following loop:

    for (const GlobalObject *const G : llvm::concat<const GlobalObject *const>(
           make_range(GOContributions.begin(), GOContributions.end()),
           make_range(GODependencies.begin(), GODependencies.end()))) {

When Adding GO's 'contributions' and 'dependencies' to its hash value, the above loop treats the 'contributions' and 'dependencies' vertices as being the same even though their respective arrows point in different directions. The loop should be split into the two separated loops. This results in separating the 'visited' table for the two directions. In other words, the contributions get a 'visited' map and the dependencies get a separate map. However, 'contributions' cannot form loops since 1) only global variables have 'contributions' and 2) all 'contributions' are functions. Therefore, the 'contributions' can be simplified not to record 'visited' table, which avoids having two 'visited' maps.

This patch will stop the algorithm from a) thinking that it’s detecting lots of loops and b) accumulating unnecessary successors.

The upstream LLVM+Clang is used as an application to check the performance. After applying this commit, the LLVM backend time for the first time build changed from 10310.6s to 9421.7s (8.62%improvement). The backend time for the second time build changed from 1886.4s to 901.8s (52.19% improvement).

Fix for <https://github.com/SNSystems/llvm-project-prepo/issues/34>.