### PR TITLE
Fixing a missed GlobalDCEPass issue.

### DIFF
--- a/llvm/test/Feature/Repo/repo-opt-pipeline.ll
+++ b/llvm/test/Feature/Repo/repo-opt-pipeline.ll
@@ -8,15 +8,15 @@
 ; RUN: env REPOFILE=%t3.db opt -mtriple="x86_64-pc-linux-gnu-repo" -O3 -debug-pass=Structure < %s -o /dev/null 2>&1 | FileCheck %s
 ; RUN: rm -f %t4.db
 ; RUN: env REPOFILE=%t4.db opt -mtriple="x86_64-pc-linux-gnu-repo" -Os -debug-pass=Structure < %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: rm -f %t5.db
+; RUN: env REPOFILE=%t5.db opt -mtriple="x86_64-pc-linux-gnu-repo" -debug-pass=Structure < %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 
-; CHECK:      Profile summary info
-; CHECK-NEXT:   ModulePass Manager
+; CHECK:       ModulePass Manager
 ; CHECK-NEXT:     RepoMetadataGenerationPass
 ; CHECK-NEXT:     RepoPruningPass
 ; CHECK-NEXT:     Dead Global Elimination
-; CHECK-NEXT:     Force set function attributes
 
 define void @f() {
   ret void

--- a/llvm/test/Feature/Repo/repo_InsertOrExtraValueInst_hash.ll
+++ b/llvm/test/Feature/Repo/repo_InsertOrExtraValueInst_hash.ll
@@ -3,13 +3,14 @@
 ;
 ; RUN: rm -f %t.db
 ; RUN: env REPOFILE=%t.db opt -S %s -o %t
-; RUN: env REPOFILE=%t.db opt -S %t | FileCheck %s
+; RUN: env REPOFILE=%t.db llc -mtriple="x86_64-pc-linux-gnu-repo" -filetype=obj %t -o %t.1.o
+; RUN: env REPOFILE=%t.db opt -S %s | FileCheck %s
 
 target triple = "x86_64-pc-linux-gnu-repo"
 
-@.str = private unnamed_addr constant [9 x i8] c"test.cpp\00", align 1
+@.str = unnamed_addr constant [9 x i8] c"test.cpp\00", align 1
 
-define internal void @__cxx_global_var_init() section ".text.startup" personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*) {
+define void @__cxx_global_var_init() section ".text.startup" personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*) {
   %exn.slot = alloca i8*
   %ehselector.slot = alloca i32
 
@@ -22,6 +23,6 @@ define internal void @__cxx_global_var_init() section ".text.startup" personalit
 
 declare i32 @__gxx_personality_v0(...)
 
-;CHECK: !0 = !RepoDefinition(name: ".str",
-;CHECK-NEXT: !1 = !RepoDefinition(name: "__cxx_global_var_init",
+;CHECK: !0 = !RepoDefinition(name: {{.*}}, digest: [16 x i8] c"{{.*}}", linkage: external, visibility: default, pruned: true)
+;CHECK-NEXT: !1 = !RepoDefinition(name: {{.*}}, digest: [16 x i8] c"{{.*}}", linkage: external, visibility: default, pruned: true)
 ;CHECK-NOT: !2 = !RepoDefinition(name:

--- a/llvm/test/Feature/Repo/repo_alias_aliasOfAlias.ll
+++ b/llvm/test/Feature/Repo/repo_alias_aliasOfAlias.ll
@@ -7,17 +7,27 @@
 
 target triple = "x86_64-pc-linux-gnu-repo"
 
-
-;CHECK: declare void @A()
+;CHECK-NOT: @A = alias void ()
+;CHECK-NOT: declare void @A()
 @A = alias void (), void ()* @D
 
-;CHECK: declare void @B()
+;CHECK-NOT: @B = alias void ()
+;CHECK-NOT: declare void @B()
 @B = alias void (), bitcast (void ()* @D to void ()*)
 
-;CHECK: declare void @C()
+;CHECK-NOT: @C = alias void ()
+;CHECK-NOT: declare void @C()
 @C = alias void (), void ()* @B
 
+;CHECK-NOT: @D = alias void ()
+;CHECK-NOT: declare void @D()
 define void @D() {
 entry:
   ret void
 }
+
+;CHECK: !0 = !RepoDefinition(name: {{.*}}, digest: [16 x i8] c"[[FOO:.+]]", linkage: external, visibility: default, pruned: true)
+;CHECK: !1 = !RepoDefinition(name: {{.*}}, digest: [16 x i8] c"[[FOO]]", linkage: external, visibility: default, pruned: true)
+;CHECK: !2 = !RepoDefinition(name: {{.*}}, digest: [16 x i8] c"[[FOO]]", linkage: external, visibility: default, pruned: true)
+;CHECK: !3 = !RepoDefinition(name: {{.*}}, digest: [16 x i8] c"[[FOO]]", linkage: external, visibility: default, pruned: true)
+

--- a/llvm/tools/opt/opt.cpp
+++ b/llvm/tools/opt/opt.cpp
@@ -886,6 +886,7 @@ int main(int argc, char **argv) {
       !OptLevelO2 && !OptLevelOs && !OptLevelOz && !OptLevelO3) {
     Passes.add(createRepoMetadataGenerationPass());
     Passes.add(createRepoPruningPass());
+    Passes.add(createGlobalDCEPass());
   }
 
   if (FPasses) {


### PR DESCRIPTION
When using opt.exe with no optimisation level and tergeted on the Repo, the GlobalDCE pass is missing after the RepoPruning pass.

Fix for <https://github.com/SNSystems/llvm-project-prepo/issues/103>