### PR TITLE
Alignment of common symbols

### DIFF
--- a/llvm/test/Feature/Repo/repo_common_symbol.ll
+++ b/llvm/test/Feature/Repo/repo_common_symbol.ll
@@ -14,7 +14,7 @@ target triple = "x86_64-pc-linux-gnu-repo"
 !0 = !RepoDefinition(name: "a", digest: [16 x i8] c"\22\CE\E5\A0\D2t\C9h\9D\D1M\15\F7L\B4\A2", linkage: common, visibility: default, pruned: false)
 
 ; CHECK: Name: a (
-; CHECK-NEXT: Value: 0x0
+; CHECK-NEXT: Value: 0x4
 ; CHECK-NEXT: Size: 4
 ; CHECK-NEXT: Binding: Global (0x1)
 ; CHECK-NEXT: Type: Object (0x1)

--- a/llvm/tools/repo2obj/R2OELFOutputSection.h
+++ b/llvm/tools/repo2obj/R2OELFOutputSection.h
@@ -239,9 +239,9 @@ OutputSection<ELFT>::SectionInfo::symbol(SymbolTable<ELFT> &Symbols,
     static auto PrivateSymbolCount = 0U;
 
     auto Name = Generated.add(".LR" + std::to_string(PrivateSymbolCount++));
-    Symbol_ = Symbols.insertSymbol(Name, Section_, Offset_, 0 /*size*/,
-                                   pstore::repo::linkage::internal,
-                                   pstore::repo::visibility::default_vis);
+    Symbol_ = Symbols.insertSymbol(
+        Name, Section_, Offset_, 0 /*size*/, pstore::repo::linkage::internal,
+        1U /*alignment*/, pstore::repo::visibility::default_vis);
 
     LLVM_DEBUG(dbgs() << "  created symbol:" << Name
                       << " for internal fixup (offset:" << Offset_
@@ -258,7 +258,6 @@ OutputSection<ELFT>::SectionInfo::symbol(SymbolTable<ELFT> &Symbols,
 // so that it's easier in the short term to replicate it here. Refactor.
 /// \brief Write a sequence of optimal nops to the output, covering \p Count
 /// bytes.
-/// \return - true on success, false on failure
 template <typename ELFT>
 void OutputSection<ELFT>::writeNopData(llvm::raw_ostream &OS,
                                        uint64_t Count) const {
@@ -365,7 +364,7 @@ void OutputSection<ELFT>::append(pstore::repo::compilation_member const &CM,
 
   if (CM.linkage() != pstore::repo::linkage::append) {
     Symbols.insertSymbol(pstore::indirect_string::read(Db_, CM.name), this,
-                         SectionSize_, ObjectSize, CM.linkage(),
+                         SectionSize_, ObjectSize, CM.linkage(), DataAlign,
                          CM.visibility());
   }
 

--- a/llvm/tools/repo2obj/repo2obj.cpp
+++ b/llvm/tools/repo2obj/repo2obj.cpp
@@ -515,20 +515,20 @@ int main(int argc, char *argv[]) {
         auto const Name = pstore::indirect_string::read(Db, CM.name);
         assert(Name.is_in_store());
 
-        if (!Fragment->has_section(pstore::repo::section_kind::bss)
-            || std::count_if (Fragment->begin (), Fragment->end (), pstore::repo::is_target_section) != 1) {
-
+        if (!Fragment->has_section(pstore::repo::section_kind::bss) ||
+            std::count_if(Fragment->begin(), Fragment->end(),
+                          pstore::repo::is_target_section) != 1) {
           pstore::shared_sstring_view Owner;
           error("Fragment for common symbol \"" +
                 Name.as_string_view(&Owner).to_string() +
                 "\" did not contain a sole BSS section");
         }
 
-        pstore::repo::bss_section const &S =
+        pstore::repo::bss_section const &BSS =
             Fragment->at<pstore::repo::section_kind::bss>();
         State->Symbols.insertSymbol(Name, nullptr /*no output section*/,
-                                    0 /*offset*/, S.size(), Linkage,
-                                    CM.visibility());
+                                    0 /*offset*/, BSS.size(), Linkage,
+                                    BSS.align(), CM.visibility());
         continue;
       }
       // Go through the sections that this fragment contains creating the


### PR DESCRIPTION
A fix for issue #105. In ELF, common symbol alignment is given by the symbol's st_value field since there is no data explicitly associated with the symbol.