### PR TITLE
Fixing an undefined reference error which is caused by incorrect hash calculation.

### DIFF
--- a/llvm/lib/IR/RepoDefinition.cpp
+++ b/llvm/lib/IR/RepoDefinition.cpp
@@ -90,24 +90,30 @@ const Constant *getAliasee(const GlobalAlias *GA) {
 
 template <typename GlobalType>
 void ModuleHashGenerator::calculateGOInfo(const GlobalType *G) {
-  GOInfo Result = calculateDigestAndDependenciesAndContributedToGVs(G);
-  // ContributedToGVs of an object is used to update other objects'
-  // contributions. For example, if the ContributedToGVs of function `foo`  are
-  // global variables `g` and `q`, the function `foo` is in the contributions of
-  // `g` and `q`.
-  // ContributedToGVs[`foo`] = [`g`, `q`]
-  // ====> Contributions[`g`] = [`foo`],
-  //       Contributions[`q`] = [`foo`]
+  GODetailedInfo Result = calculateDigestAndDependenciesAndContributions(G);
+  // Contributions of an object is used to update other objects' Dependencies.
+  // For example, if the Contributions of function `foo`  are global variables
+  // `g` and `q`, the function `foo` is added into the Dependencies of `g` and
+  // `q`.
+  // For example, Contributions[`foo`] = [`g`, `q`]
+  // ====> Dependencies[`g`] = [`foo`],
+  //       Dependencies[`q`] = [`foo`]
+  //
+  // Contributions were initially known as "reverse dependencies". If the
+  // contribution/reverse-dependency is swapped for a normal (forward)
+  // dependency. The meaning is unchanged. The below loop converts the
+  // Contributions to Dependencies and then just record the resulting graph in
+  // the hash.
   for (auto &GO : Result.Contributions) {
     assert(isa<GlobalVariable>(GO) &&
            "Only global variables can have contributions!");
     assert(isa<llvm::Function>(G) && "All contributions are functions!");
-    GOIMap[GO].Contributions.emplace_back(G);
+    GOIMap[GO].Dependencies.emplace_back(G);
   }
   // Update G's dependencies.
   GOInfo &GInfo = GOIMap[G];
-  GInfo.InitialDigest = std::move(Result.InitialDigest);
-  GInfo.Dependencies = std::move(Result.Dependencies);
+  GInfo.InitialDigest = std::move(Result.HashInfo.InitialDigest);
+  GInfo.Dependencies = std::move(Result.HashInfo.Dependencies);
 }
 
 void ModuleHashGenerator::calculateGOInfo(const GlobalObject *GO) {
@@ -120,9 +126,9 @@ void ModuleHashGenerator::calculateGOInfo(const GlobalObject *GO) {
   }
 }
 
-GODigestState
-ModuleHashGenerator::accumulateGODigest(const GlobalObject *GO, MD5 &GOHash,
-                                        bool UseRepoDefinitionMD) {
+GOVec ModuleHashGenerator::accumulateGODigest(const GlobalObject *GO,
+                                              MD5 &GOHash,
+                                              bool UseRepoDefinitionMD) {
   if (UseRepoDefinitionMD) {
     if (const auto *const GOMD =
             GO->getMetadata(LLVMContext::MD_repo_definition)) {
@@ -130,11 +136,9 @@ ModuleHashGenerator::accumulateGODigest(const GlobalObject *GO, MD5 &GOHash,
         DigestType D = RD->getDigest();
         GOHash.update(D.Bytes);
         const GOInfo &GOInformation =
-            GOIMap.try_emplace(GO, std::move(D), GOVec(), GOVec())
-                .first->second;
+            GOIMap.try_emplace(GO, std::move(D), GOVec()).first->second;
         Changed = true;
-        return GODigestState(GOInformation.Contributions,
-                             GOInformation.Dependencies);
+        return GOInformation.Dependencies;
       }
       report_fatal_error("Failed to get RepoDefinition metadata!");
     }
@@ -143,7 +147,7 @@ ModuleHashGenerator::accumulateGODigest(const GlobalObject *GO, MD5 &GOHash,
   const GOInfo &GOInformation = GOIMap[GO];
   GOHash.update(GOInformation.InitialDigest.Bytes);
   Changed = true;
-  return GODigestState(GOInformation.Contributions, GOInformation.Dependencies);
+  return GOInformation.Dependencies;
 }
 
 // Calculate the GOs' initial digest, dependencies, contributions and the
@@ -169,27 +173,19 @@ void ModuleHashGenerator::calculateGONumAndGOIMap(const Module &M) {
 #endif
 }
 
-void ModuleHashGenerator::updateDigestUseContributions(
-    MD5 &GOHash, const GOVec &Contributions) {
-  for (const GlobalObject *const G : Contributions) {
-    GOHash.update(GOIMap[G].InitialDigest.Bytes);
-  }
-  // GOHash/Module is changed if Contributions is not empty.
-  Changed = Changed || !Contributions.empty();
-}
-
 auto ModuleHashGenerator::updateDigestUseDependencies(const GlobalObject *GO,
                                                       MD5 &GOHash,
                                                       unsigned GODepth,
                                                       const GOVec &Dependencies,
                                                       bool UseRepoDefinitionMD)
     -> std::tuple<size_t, DigestType> {
+  // GOHash/Module is changed if Dependencies is not empty.
+  Changed = Changed || !Dependencies.empty();
   auto LoopPoint = std::numeric_limits<size_t>::max();
   for (const GlobalObject *const G : Dependencies) {
     size_t GDepth;
     DigestType GDigest;
-    std::tie(GDepth, GDigest) =
-        updateDigestUseDependenciesAndContributions(G, UseRepoDefinitionMD);
+    std::tie(GDepth, GDigest) = updateDigest(G, UseRepoDefinitionMD);
     // A GO which loops back to itself doesn't count as a loop.
     if (G != GO)
       LoopPoint = std::min(LoopPoint, GDepth);
@@ -214,8 +210,8 @@ auto ModuleHashGenerator::updateDigestUseDependencies(const GlobalObject *GO,
   return std::make_tuple(LoopPoint, Digest);
 }
 
-auto ModuleHashGenerator::updateDigestUseDependenciesAndContributions(
-    const GlobalObject *GO, bool UseRepoDefinitionMD)
+auto ModuleHashGenerator::updateDigest(const GlobalObject *GO,
+                                       bool UseRepoDefinitionMD)
     -> std::tuple<size_t, DigestType> {
   assert(!GO->isDeclaration() && "Can only be used for global definitions");
 
@@ -256,27 +252,16 @@ auto ModuleHashGenerator::updateDigestUseDependenciesAndContributions(
   }
 
   GOHash.update(static_cast<char>(Tags::GO));
-  auto State = accumulateGODigest(GO, GOHash, UseRepoDefinitionMD);
-  // The hashes of the GO's 'contributions' and 'dependencies' are separately
-  // added to the GO's hash since their respective arrows point are in different
-  // direction. In addition, 'contributions' cannot form loops since 1) only
-  // global variables have 'contributions' and 2) all 'contributions' are
-  // functions. Therefore, the 'contributions' can be simplified not to record
-  // 'visited' map, which avoids having two 'visited' maps. Firstly, add the
-  // GO's contributions to its hash.
-  updateDigestUseContributions(GOHash, State.Contributions);
-
+  auto Dependencies = accumulateGODigest(GO, GOHash, UseRepoDefinitionMD);
   // Add the GO's dependencies to its hash.
-  return updateDigestUseDependencies(GO, GOHash, GODepth, State.Dependencies,
+  return updateDigestUseDependencies(GO, GOHash, GODepth, Dependencies,
                                      UseRepoDefinitionMD);
-  ;
 }
 
 DigestType ModuleHashGenerator::calculateDigest(const GlobalObject *GO,
                                                 bool UseRepoDefinitionMD) {
   Visited.clear();
-  return std::get<DigestType>(
-      updateDigestUseDependenciesAndContributions(GO, UseRepoDefinitionMD));
+  return std::get<DigestType>(updateDigest(GO, UseRepoDefinitionMD));
 }
 
 void ModuleHashGenerator::digestModule(Module &M) {

--- a/llvm/lib/IR/RepoHashCalculator.cpp
+++ b/llvm/lib/IR/RepoHashCalculator.cpp
@@ -541,13 +541,13 @@ void FunctionHashCalculator::hashInstruction(const Instruction *V,
     update(HashKind::TAG_CallInst);
     update(CI->isTailCall());
     hashCallInvoke(CI);
-    addContributedToGVsFromCallInvoke(CI);
+    addContributionsFromCallInvoke(CI);
     return;
   }
   if (const InvokeInst *II = dyn_cast<InvokeInst>(V)) {
     update(HashKind::TAG_InvokeInst);
     hashCallInvoke(II);
-    addContributedToGVsFromCallInvoke(II);
+    addContributionsFromCallInvoke(II);
     return;
   }
 
@@ -581,7 +581,7 @@ void FunctionHashCalculator::hashInstruction(const Instruction *V,
     FnHash.hashOrdering(SI->getOrdering());
     update(SI->getSyncScopeID());
     if (auto *GV = getStoreAddress(SI)) {
-      FnHash.getContributedToGVs().emplace_back(GV);
+      FnHash.getContributions().emplace_back(GV);
     }
     return;
   }
@@ -686,8 +686,8 @@ void FunctionHashCalculator::calculateHash() {
   for (auto D : FnHash.getDependencies()) {
     LLVM_DEBUG(dbgs() << D->getName() << ", ");
   }
-  LLVM_DEBUG(dbgs() << ". Its ContributedToGVs are: ");
-  for (auto C : FnHash.getContributedToGVs()) {
+  LLVM_DEBUG(dbgs() << ". Its Contributions are: ");
+  for (auto C : FnHash.getContributions()) {
     LLVM_DEBUG(dbgs() << C->getName() << ", ");
   }
   LLVM_DEBUG(dbgs() << "\n");

--- a/llvm/test/Feature/Repo/Inputs/repo_contributions_dependencies_loop.ll
+++ b/llvm/test/Feature/Repo/Inputs/repo_contributions_dependencies_loop.ll
@@ -1,0 +1,30 @@
+target triple = "x86_64-pc-linux-gnu-elf"
+
+%"T1" = type { i8* }
+%"T2" = type { i32 (...)**, i32, i8* }
+
+@Var1 = constant { [1 x i8*] } { [1 x i8*] [i8* bitcast (i8* (%T1*, i8*)* @Func1 to i8*)] }, align 8
+@Var2 = global %"T2" zeroinitializer, align 8
+
+define i8* @Func1(%T1* %this, i8* %R) {
+entry:
+  %R.addr = alloca i8*, align 8
+  %R2 = getelementptr inbounds %T1, %T1* %this, i32 0, i32 0
+  store i8* %R, i8** %R2, align 8
+  ret i8* %R
+}
+
+; Function Attrs: nounwind uwtable
+define void @Main() {
+entry:
+  call void @Func2(%"T2"* @Var2)
+  ret void
+}
+
+; Function Attrs: nounwind uwtable
+define void @Func2(%"T2"* %this) {
+entry:
+  %0 = bitcast %"T2"* %this to i32 (...)***
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [1 x i8*] }, { [1 x i8*] }* @Var1, i32 0, inrange i32 0, i32 2) to i32 (...)**), i32 (...)*** %0, align 8
+  ret void
+}

--- a/llvm/test/Feature/Repo/repo_hash_contributions.ll
+++ b/llvm/test/Feature/Repo/repo_hash_contributions.ll
@@ -1,0 +1,49 @@
+; This test is used to check the hash calculation for the contributions.
+;
+; Although 'contributions' and 'dependencies' respective arrows point are
+; in different direction, they can affect each other and form loops.
+;
+; The test invokes five steps:
+;  1) Compile the initial code `Inputs/repo_contributions_dependencies_loop.ll`;
+;  2) Compiled `repo_hash_contributions.ll`.
+;  3) Dump the digest of `Var2` in %t.
+;  4) Dump the digest of `Var2` in %t1.
+;  5) Check the digests of `Var2` are different since the function `Func1` is changed.
+;
+; RUN: rm -rf %t.db
+; RUN: env REPOFILE=%t.db clang -c -O0 --target=x86_64-pc-linux-gnu-repo -x ir %S/Inputs/repo_contributions_dependencies_loop.ll -o %t
+; RUN: env REPOFILE=%t.db clang -c -O0 --target=x86_64-pc-linux-gnu-repo -x ir %s -o %t1
+; RUN: env REPOFILE=%t.db repo-fragments %t -names=Var2 -repo=%t.db -digest-only > %t.d
+; RUN: env REPOFILE=%t.db repo-fragments %t1 -names=Var2 -repo=%t.db -digest-only > %t1.d
+; RUN: not diff %t.d %t1.d
+
+target triple = "x86_64-pc-linux-gnu-elf"
+
+%"T1" = type { i8* }
+%"T2" = type { i32 (...)**, i32, i8* }
+
+@Var1 = constant { [1 x i8*] } { [1 x i8*] [i8* bitcast (i8* (%T1*, i8*)* @Func1 to i8*)] }, align 8
+@Var2 = global %"T2" zeroinitializer, align 8
+
+define i8* @Func1(%T1* %this, i8* %R) {
+entry:
+  %R.addr = alloca i8*, align 16
+  %R2 = getelementptr inbounds %T1, %T1* %this, i32 0, i32 0
+  store i8* %R, i8** %R2, align 16
+  ret i8* %R
+}
+
+; Function Attrs: nounwind uwtable
+define void @Main() {
+entry:
+  call void @Func2(%"T2"* @Var2)
+  ret void
+}
+
+; Function Attrs: nounwind uwtable
+define void @Func2(%"T2"* %this) {
+entry:
+  %0 = bitcast %"T2"* %this to i32 (...)***
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [1 x i8*] }, { [1 x i8*] }* @Var1, i32 0, inrange i32 0, i32 2) to i32 (...)**), i32 (...)*** %0, align 8
+  ret void
+}

--- a/llvm/test/Feature/Repo/repo_hash_dependencies.ll
+++ b/llvm/test/Feature/Repo/repo_hash_dependencies.ll
@@ -1,0 +1,49 @@
+; This test is used to check the hash calculation for the dependencies.
+;
+; Although 'contributions' and 'dependencies' respective arrows point are
+; in different direction, they can affect each other and form loops.
+;
+; The test invokes five steps:
+;  1) Compile the initial code `Inputs/repo_contributions_dependencies_loop.ll`;
+;  2) Compiled `repo_hash_dependencies.ll`.
+;  3) Dump the digest of `Main` in %t.
+;  4) Dump the digest of `Main` in %t1.
+;  5) Check the digests of `Main` are different since the function `Func1` is changed.
+;
+; RUN: rm -rf %t.db
+; RUN: env REPOFILE=%t.db clang -c -O0 --target=x86_64-pc-linux-gnu-repo -x ir %S/Inputs/repo_contributions_dependencies_loop.ll -o %t
+; RUN: env REPOFILE=%t.db clang -c -O0 --target=x86_64-pc-linux-gnu-repo -x ir %s -o %t1
+; RUN: env REPOFILE=%t.db repo-fragments %t -names=Main -repo=%t.db -digest-only > %t.d
+; RUN: env REPOFILE=%t.db repo-fragments %t1 -names=Main -repo=%t.db -digest-only > %t1.d
+; RUN: not diff %t.d %t1.d
+
+target triple = "x86_64-pc-linux-gnu-elf"
+
+%"T1" = type { i8* }
+%"T2" = type { i32 (...)**, i32, i8* }
+
+@Var1 = constant { [1 x i8*] } { [1 x i8*] [i8* bitcast (i8* (%T1*, i8*)* @Func1 to i8*)] }, align 8
+@Var2 = global %"T2" zeroinitializer, align 16
+
+define i8* @Func1(%T1* %this, i8* %R) {
+entry:
+  %R.addr = alloca i8*, align 8
+  %R2 = getelementptr inbounds %T1, %T1* %this, i32 0, i32 0
+  store i8* %R, i8** %R2, align 8
+  ret i8* %R
+}
+
+; Function Attrs: nounwind uwtable
+define void @Main() {
+entry:
+  call void @Func2(%"T2"* @Var2)
+  ret void
+}
+
+; Function Attrs: nounwind uwtable
+define void @Func2(%"T2"* %this) {
+entry:
+  %0 = bitcast %"T2"* %this to i32 (...)***
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [1 x i8*] }, { [1 x i8*] }* @Var1, i32 0, inrange i32 0, i32 2) to i32 (...)**), i32 (...)*** %0, align 8
+  ret void
+}

--- a/llvm/unittests/IR/RepoDefinitionTest.cpp
+++ b/llvm/unittests/IR/RepoDefinitionTest.cpp
@@ -100,12 +100,8 @@ TEST_F(SingleModule, NoCalleeSame) {
   EXPECT_EQ(FooInfo.InitialDigest, BarInfo.InitialDigest)
       << "Expected that functions of foo and bar have the same initial hash "
          "value";
-  EXPECT_TRUE(FooInfo.Contributions.empty())
-      << "Expected that the foo's contribution list is empty.";
   EXPECT_TRUE(FooInfo.Dependencies.empty())
       << "Expected that the foo's dependencies list is empty.";
-  EXPECT_TRUE(BarInfo.Contributions.empty())
-      << "Expected that the bar's contributions list is empty.";
   EXPECT_TRUE(BarInfo.Dependencies.empty())
       << "Expected that the bar's dependencies list is empty.";
   // Check the GOs' final digest.
@@ -171,12 +167,8 @@ TEST_F(SingleModule, OneCalleeSameNameSameBody) {
   EXPECT_EQ(FooInfo.InitialDigest, BarInfo.InitialDigest)
       << "Expected that functions of foo and bar have the same initial hash "
          "value";
-  EXPECT_TRUE(FooInfo.Contributions.empty())
-      << "Expected that the foo's contributions list is empty.";
   EXPECT_THAT(FooInfo.Dependencies, ::testing::UnorderedElementsAre(G))
       << "Expected foo's Dependencies list is { G }";
-  EXPECT_TRUE(BarInfo.Contributions.empty())
-      << "Expected that the bar's contributions list is empty.";
   EXPECT_THAT(BarInfo.Dependencies, ::testing::UnorderedElementsAre(G))
       << "Expected bar's Dependencies list is { G }";
   // Check the GOs' final digest.
@@ -225,12 +217,8 @@ TEST_F(SingleModule, OneCalleeDiffNameSameBody) {
   EXPECT_NE(FooInfo.InitialDigest, BarInfo.InitialDigest)
       << "Expected that functions of foo and bar have the different initial "
          "hash value";
-  EXPECT_TRUE(FooInfo.Contributions.empty())
-      << "Expected that the foo's contributions list is empty.";
   EXPECT_THAT(FooInfo.Dependencies, ::testing::UnorderedElementsAre(G))
       << "Expected foo's Dependencies list is { G }";
-  EXPECT_TRUE(BarInfo.Contributions.empty())
-      << "Expected that the bar's contributions list is empty.";
   EXPECT_THAT(BarInfo.Dependencies, ::testing::UnorderedElementsAre(P))
       << "Expected bar's Dependencies list is { P }";
   // Check the GOs' final digest.
@@ -373,12 +361,8 @@ TEST_F(SingleModule, CallEachOther) {
   EXPECT_NE(FooInfo.InitialDigest, BarInfo.InitialDigest)
       << "Expected that functions of foo and bar have the different initial "
          "hash value";
-  EXPECT_TRUE(FooInfo.Contributions.empty())
-      << "Expected that the foo's contributions list is empty.";
   EXPECT_THAT(FooInfo.Dependencies, ::testing::ElementsAre(Bar))
       << "Expected foo's Dependencies list is {bar}";
-  EXPECT_TRUE(BarInfo.Contributions.empty())
-      << "Expected that the bar's contributions list is empty.";
   EXPECT_THAT(BarInfo.Dependencies, ::testing::ElementsAre(Foo))
       << "Expected bar's Dependencies list is {foo}";
   // Check the GOs' final digest.
@@ -430,16 +414,10 @@ TEST_F(SingleModule, OneCalleeLoop) {
   EXPECT_EQ(FooInfo.InitialDigest, BarInfo.InitialDigest)
       << "Expected that functions of foo and bar have the same initial hash "
          "value";
-  EXPECT_TRUE(FooInfo.Contributions.empty())
-      << "Expected that the foo's contributions list is empty.";
   EXPECT_THAT(FooInfo.Dependencies, ::testing::ElementsAre(P))
       << "Expected foo's Dependencies list is {P}";
-  EXPECT_TRUE(BarInfo.Contributions.empty())
-      << "Expected that the bar's contributions list is empty.";
   EXPECT_THAT(BarInfo.Dependencies, ::testing::ElementsAre(P))
       << "Expected bar's Dependencies list is {P}";
-  EXPECT_TRUE(PInfo.Contributions.empty())
-      << "Expected that the p's contributions list is empty.";
   EXPECT_THAT(PInfo.Dependencies, ::testing::ElementsAre(Bar))
       << "Expected p's Dependencies list is {bar}";
   // Check the GOs' final digest.
@@ -519,24 +497,14 @@ TEST_F(SingleModule, TwolevelsCall) {
       << "Expected that functions of foo and bar have the same initial "
          "hash value";
 
-  EXPECT_TRUE(ZInfo.Contributions.empty())
-      << "Expected that the z's Contributions list is empty.";
   EXPECT_TRUE(ZInfo.Dependencies.empty())
       << "Expected that the z's Dependencies list is empty.";
-  EXPECT_TRUE(QInfo.Contributions.empty())
-      << "Expected that the q's Contributions list is empty.";
   EXPECT_TRUE(QInfo.Dependencies.empty())
       << "Expected that the q's Dependencies list is empty.";
-  EXPECT_TRUE(PInfo.Contributions.empty())
-      << "Expected that the p's Contributions list is empty.";
   EXPECT_THAT(PInfo.Dependencies, ::testing::ElementsAre(Z))
       << "Expected that the p's Dependencies list is {Z}";
-  EXPECT_TRUE(FooInfo.Contributions.empty())
-      << "Expected that the foo's Contributions list is empty.";
   EXPECT_THAT(FooInfo.Dependencies, ::testing::UnorderedElementsAre(P, Q))
       << "Expected that the foo's Dependencies list is {P, Q}";
-  EXPECT_TRUE(BarInfo.Contributions.empty())
-      << "Expected that the bar's Contributions list is empty.";
   EXPECT_THAT(BarInfo.Dependencies, ::testing::UnorderedElementsAre(P, Q))
       << "Expected that the bar's Dependencies list is {P, Q}";
   EXPECT_TRUE(repodefinition::generateRepoDefinitions(*M))
@@ -583,16 +551,10 @@ TEST_F(SingleModule, SingleContribution) {
   const Function *Setto = M->getFunction("setto");
   const repodefinition::GOInfo &SettoInfo = InfoMap[Setto];
 
-  EXPECT_THAT(ZInfo.Contributions, ::testing::UnorderedElementsAre(Test))
-      << "Expected that the Z's Contributions list is {Test}";
-  EXPECT_TRUE(ZInfo.Dependencies.empty())
-      << "Expected that Z's Dependencies list is empty";
-  EXPECT_TRUE(TestInfo.Contributions.empty())
-      << "Expected that the test's Contributions list is empty.";
+  EXPECT_THAT(ZInfo.Dependencies, ::testing::UnorderedElementsAre(Test))
+      << "Expected that the Z's Dependencies list is {Test}";
   EXPECT_THAT(TestInfo.Dependencies, ::testing::UnorderedElementsAre(Z, Setto))
       << "Expected that the test's Dependencies list is {Z, setto}";
-  EXPECT_TRUE(SettoInfo.Contributions.empty())
-      << "Expected that the setto's Contributions list is empty.";
   EXPECT_TRUE(SettoInfo.Dependencies.empty())
       << "Expected that the setto's Dependencies list is empty.";
 }
@@ -644,11 +606,9 @@ TEST_F(SingleModule, MultipleContribution) {
   const Function *Test1 = M->getFunction("test1");
   const Function *Test2 = M->getFunction("test2");
 
-  EXPECT_THAT(ZInfo.Contributions,
+  EXPECT_THAT(ZInfo.Dependencies,
               ::testing::UnorderedElementsAre(Test, Test1, Test2))
-      << "Expected that the Z's Contributions list is {Test, Test1, Test2}";
-  EXPECT_TRUE(ZInfo.Dependencies.empty())
-      << "Expected that Z's Dependencies list is empty";
+      << "Expected that the Z's Dependencies list is {Test, Test1, Test2}";
 }
 
 // The definition metadate fixture for double modules.


### PR DESCRIPTION
If a global variable has the Contributions, it cannot be cached since it might be changed by its contributions. In the repo hash algorithm, the contributions and dependencies should be treated equally.

Fix for https://github.com/SNSystems/llvm-project-prepo/issues/110