### PR TITLE
Performance Improvement for the hash algorithm.

### DIFF
--- a/llvm/lib/IR/RepoDefinition.cpp
+++ b/llvm/lib/IR/RepoDefinition.cpp
@@ -186,12 +186,6 @@ auto ModuleHashGenerator::updateDigestUseDependencies(const GlobalObject *GO,
     -> std::tuple<size_t, DigestType> {
   auto LoopPoint = std::numeric_limits<size_t>::max();
   for (const GlobalObject *const G : Dependencies) {
-    const llvm::Function *const Fn = dyn_cast<const llvm::Function>(G);
-    // if function will not be inlined and not be discarded if it is not used,
-    // skip it.
-    if (Fn && Fn->hasFnAttribute(Attribute::NoInline) &&
-        !Fn->isDiscardableIfUnused())
-      continue;
     size_t GDepth;
     DigestType GDigest;
     std::tie(GDepth, GDigest) =

--- a/llvm/test/Feature/Repo/repo_dependencies_noInline.ll
+++ b/llvm/test/Feature/Repo/repo_dependencies_noInline.ll
@@ -1,0 +1,22 @@
+; Check that @Z is @f's only dependency. @g is not included because it is a noinline function.
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -O3 -debug-only prepo-digest -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@Z = global i32 1
+define void @f() noinline {
+    call void @g( i32* @Z, i32 3 )
+    ret void
+}
+
+define void @g(i32* %P, i32 %V) noinline {
+    store i32 %V, i32* %P
+    ret void
+}
+
+;CHECK: GO Name:f
+;CHECK:    Dependencies: [ Z]


### PR DESCRIPTION
When calculating the GO's hash, if GO's dependencies is a function, which will not be inlined and not be discarded if it is not used, the function hash will not be accumulated to the GO's hash. We could move the check to the earlier stage when building the GO's dependencies. If a function is satisfied the above conditions, it will not be added into the dependencies. It will reduce the size of GO's dependencies.

The llvm-project (commit: a822ec75) is used to measure the performance improvement.

The backend compilation time of the repo compiler (master: d93faf2) is 17166.0s. After this commit, the backend compilation time is 15604.4s. The backend compilation time is reduced by 1,561.6s (9.1% improvement).