### PR TITLE
Adding a repo-fragments tool.

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -157,6 +157,10 @@ if(LLVM_TOOL_REPO_TICKET_DUMP_BUILD)
   set(LLVM_TEST_DEPENDS ${LLVM_TEST_DEPENDS} repo-ticket-dump)
 endif()
 
+if(LLVM_TOOL_REPO_FRAGMENTS_BUILD)
+  set(LLVM_TEST_DEPENDS ${LLVM_TEST_DEPENDS} repo-fragments)
+endif()
+
 if(TARGET ocaml_llvm)
   # Clear all non-OCaml cross-target dependencies when building out-of-tree.
   if(LLVM_OCAML_OUT_OF_TREE)

--- a/llvm/test/tools/repo-fragments/tool-options-test.ll
+++ b/llvm/test/tools/repo-fragments/tool-options-test.ll
@@ -1,0 +1,34 @@
+; Check repo-fragments options, which include:
+;    1) Check the default case by dumping _all_ of the names from a compilation;
+;    2) Check the -names option by dumping one or more fragments by names option;
+;    3) check the -digest-only option;
+;    4) check the -comma option;
+;    5) check the -verbose option;
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db clang -c --target=x86_64-pc-linux-gnu-repo -x ir %s -o %t.o
+; RUN: env REPOFILE=%t.db repo-fragments %t.o -repo=%t.db | FileCheck --check-prefix=CHECK0 %s
+; RUN: env REPOFILE=%t.db repo-fragments %t.o -names=v -repo=%t.db | FileCheck --check-prefix=CHECK1 %s
+; RUN: env REPOFILE=%t.db repo-fragments %t.o -digest-only -repo=%t.db | FileCheck --check-prefix=CHECK2 %s
+; RUN: env REPOFILE=%t.db repo-fragments %t.o -comma -repo=%t.db | FileCheck --check-prefix=CHECK3 %s
+; RUN: env REPOFILE=%t.db repo-fragments %t.o -verbose -repo=%t.db | FileCheck --check-prefix=CHECK4 %s
+;
+; CHECK0: f: {{([[:xdigit:]]{32})}}
+; CHECK0: v: {{([[:xdigit:]]{32})}}
+; CHECK1-NOT: f: {{([[:xdigit:]]{32})}}
+; CHECK1: v: {{([[:xdigit:]]{32})}}
+; CHECK2: {{([[:xdigit:]]{32})}}
+; CHECK2: {{([[:xdigit:]]{32})}}
+; CHECK3: f: {{([[:xdigit:]]{32})}},v: {{([[:xdigit:]]{32})}}
+; CHECK4: [ticket file
+; CHECK4: {{([[:xdigit:]]{32})}}
+; CHECK4: [Compilation]:
+; CHECK4: members :
+;
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@v = global i32 1
+define void @f() {
+entry:
+  ret void
+}

--- a/llvm/test/tools/repo-fragments/tool-options-test.ll
+++ b/llvm/test/tools/repo-fragments/tool-options-test.ll
@@ -1,9 +1,8 @@
 ; Check repo-fragments options, which include:
-;    1) Check the default case by dumping _all_ of the names from a compilation;
-;    2) Check the -names option by dumping one or more fragments by names option;
-;    3) check the -digest-only option;
-;    4) check the -comma option;
-;    5) check the -verbose option;
+;    1) Check the default case by dumping all of the names from a compilation;
+;    2) Check the -names option by explicitly requesting specific definitions by name;
+;    3) Check the -digest-only option;
+;    4) Check the -comma option.
 ;
 ; RUN: rm -f %t.db
 ; RUN: env REPOFILE=%t.db clang -c --target=x86_64-pc-linux-gnu-repo -x ir %s -o %t.o
@@ -11,7 +10,6 @@
 ; RUN: env REPOFILE=%t.db repo-fragments %t.o -names=v -repo=%t.db | FileCheck --check-prefix=CHECK1 %s
 ; RUN: env REPOFILE=%t.db repo-fragments %t.o -digest-only -repo=%t.db | FileCheck --check-prefix=CHECK2 %s
 ; RUN: env REPOFILE=%t.db repo-fragments %t.o -comma -repo=%t.db | FileCheck --check-prefix=CHECK3 %s
-; RUN: env REPOFILE=%t.db repo-fragments %t.o -verbose -repo=%t.db | FileCheck --check-prefix=CHECK4 %s
 ;
 ; CHECK0: f: {{([[:xdigit:]]{32})}}
 ; CHECK0: v: {{([[:xdigit:]]{32})}}
@@ -20,10 +18,6 @@
 ; CHECK2: {{([[:xdigit:]]{32})}}
 ; CHECK2: {{([[:xdigit:]]{32})}}
 ; CHECK3: f: {{([[:xdigit:]]{32})}},v: {{([[:xdigit:]]{32})}}
-; CHECK4: [ticket file
-; CHECK4: {{([[:xdigit:]]{32})}}
-; CHECK4: [Compilation]:
-; CHECK4: members :
 ;
 target triple = "x86_64-pc-linux-gnu-repo"
 

--- a/llvm/tools/repo-fragments/CMakeLists.txt
+++ b/llvm/tools/repo-fragments/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_llvm_tool (repo-fragments
+    RepoFragments.cpp
+)
+target_link_libraries (repo-fragments PRIVATE pstore-dump-lib)
+#eof CMakeLists.txt

--- a/llvm/tools/repo-fragments/CMakeLists.txt
+++ b/llvm/tools/repo-fragments/CMakeLists.txt
@@ -1,5 +1,9 @@
+set(LLVM_LINK_COMPONENTS
+    Object
+    Support
+)
 add_llvm_tool (repo-fragments
     RepoFragments.cpp
 )
-target_link_libraries (repo-fragments PRIVATE pstore-dump-lib)
+target_link_libraries (repo-fragments PRIVATE pstore-core)
 #eof CMakeLists.txt

--- a/llvm/tools/repo-fragments/RepoFragments.cpp
+++ b/llvm/tools/repo-fragments/RepoFragments.cpp
@@ -81,13 +81,13 @@ int main(int argc, char *argv[]) {
 
   auto *Sep = "";
   for (auto const &CM : *Compilation) {
-    outs() << Sep;
-    Sep = (UseComma ? "," : "\n");
     assert(CM.name != pstore::typed_address<pstore::indirect_string>::null());
     const auto MemberName =
         pstore::indirect_string::read(Db, CM.name).to_string();
     if (Names.empty() ||
         (std::find(Names.begin(), Names.end(), MemberName) != Names.end())) {
+      outs() << Sep;
+      Sep = (UseComma ? "," : "\n");
       if (!DigestOnly)
         outs() << MemberName << ": ";
       outs() << CM.digest;

--- a/llvm/tools/repo-fragments/RepoFragments.cpp
+++ b/llvm/tools/repo-fragments/RepoFragments.cpp
@@ -16,29 +16,20 @@ using namespace llvm;
 
 namespace {
 
-static cl::OptionCategory ToolOptions("Tool Options");
-
-static cl::opt<std::string> RepoPath("repo", cl::Optional,
-                                     cl::desc("Path of the program repository"),
-                                     cl::init("./clang.db"),
-                                     cl::cat(ToolOptions));
-static cl::opt<std::string> TicketPath(cl::Positional,
-                                       cl::desc("<Path of the ticket file>"),
-                                       cl::Required, cl::cat(ToolOptions));
-static cl::list<std::string>
+cl::opt<std::string> RepoPath("repo", cl::Optional,
+                              cl::desc("Path of the program repository"),
+                              cl::init("./clang.db"));
+cl::opt<std::string> TicketPath(cl::Positional,
+                                cl::desc("<Path of the ticket file>"),
+                                cl::Required);
+cl::list<std::string>
     Names("names", cl::ZeroOrMore, cl::CommaSeparated,
-          cl::desc("<Compilation member(s) to be displayed>"),
-          cl::cat(ToolOptions));
-static cl::opt<bool> DigestOnly("digest-only", cl::init(false),
-                                cl::desc("Display the digest only"),
-                                cl::cat(ToolOptions));
-static cl::opt<bool>
+          cl::desc("<Compilation member(s) to be displayed>"));
+cl::opt<bool> DigestOnly("digest-only", cl::init(false),
+                         cl::desc("Display the digest only"));
+cl::opt<bool>
     UseComma("comma", cl::init(false),
-             cl::desc("Output fields are comma (rather than CR) separated"),
-             cl::cat(ToolOptions));
-static cl::opt<bool> Verbose("verbose", cl::init(false),
-                             cl::desc("Produce verbose output"),
-                             cl::cat(ToolOptions));
+             cl::desc("Output fields are comma (rather than CR) separated"));
 
 } // anonymous namespace
 
@@ -58,10 +49,9 @@ static std::string getRepoPath() {
 }
 
 int main(int argc, char *argv[]) {
-  cl::HideUnrelatedOptions({&ToolOptions});
   cl::ParseCommandLineOptions(argc, argv,
-                              "A repo utility for dumping the names and "
-                              "digests using a ticket file.\n");
+                              "A utility to dump a compilation's names and "
+                              "digests from a program repository.\n");
 
   ErrorOr<pstore::index::digest> DigestOrError =
       llvm::repo::getTicketIdFromFile(TicketPath);
@@ -71,50 +61,35 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
-  pstore::index::digest const &Digest = DigestOrError.get();
-  if (Verbose) {
-    outs() << "[ticket file ('" << TicketPath << ")' : \n" << Digest << "]\n\n";
-  }
-
   pstore::database Db(getRepoPath(), pstore::database::access_mode::read_only);
-  std::shared_ptr<pstore::index::compilation_index const> const
-      CompilationIndex =
-          pstore::index::get_index<pstore::trailer::indices::compilation>(Db);
+  const auto CompilationIndex =
+      pstore::index::get_index<pstore::trailer::indices::compilation>(Db);
   if (!CompilationIndex) {
     errs() << "Error: compilation index was not found. \n";
     return EXIT_FAILURE;
   }
 
+  pstore::index::digest const &Digest = DigestOrError.get();
   auto CompilationPos = CompilationIndex->find(Db, Digest);
   if (CompilationPos == CompilationIndex->end(Db)) {
-    std::string DigestStr;
-    raw_string_ostream SS{DigestStr};
-    SS << Digest;
-    errs() << "Error: compilation " + SS.str() + " was not found.\n";
+    errs() << "Error: compilation " << Digest << " was not found.\n";
     return EXIT_FAILURE;
   }
 
-  auto Ticket = pstore::repo::compilation::load(Db, CompilationPos->second);
-  if (Verbose) {
-    outs() << "[Compilation]:\n";
-    std::ostringstream out;
-    pstore::dump::value_ptr Output = pstore::dump::make_value(Db, Ticket);
-    Output->write(out);
-    outs() << out.str() << "\n\n";
-  }
+  auto Compilation =
+      pstore::repo::compilation::load(Db, CompilationPos->second);
 
-  bool IsFirst = true;
-  for (auto const &CM : *Ticket) {
-    if (!IsFirst)
-      outs() << (UseComma ? ',' : '\n');
-    IsFirst = false;
+  auto *Sep = "";
+  for (auto const &CM : *Compilation) {
+    outs() << Sep;
+    Sep = (UseComma ? "," : "\n");
     assert(CM.name != pstore::typed_address<pstore::indirect_string>::null());
-    const auto Name = pstore::indirect_string::read(Db, CM.name).to_string();
+    const auto MemberName =
+        pstore::indirect_string::read(Db, CM.name).to_string();
     if (Names.empty() ||
-        (std::find(Names.begin(), Names.end(), Name) != Names.end())) {
+        (std::find(Names.begin(), Names.end(), MemberName) != Names.end())) {
       if (!DigestOnly)
-        outs() << pstore::indirect_string::read(Db, CM.name).to_string()
-               << ": ";
+        outs() << MemberName << ": ";
       outs() << CM.digest;
     }
   }

--- a/llvm/tools/repo-fragments/RepoFragments.cpp
+++ b/llvm/tools/repo-fragments/RepoFragments.cpp
@@ -1,0 +1,124 @@
+//===- repo-fragments - Dump the names and digests using a ticket file. --===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/MC/MCRepoTicketFile.h"
+#include "llvm/Support/CommandLine.h"
+
+#include "pstore/dump/mcrepo_value.hpp"
+
+using namespace llvm;
+
+namespace {
+
+static cl::OptionCategory ToolOptions("Tool Options");
+
+static cl::opt<std::string> RepoPath("repo", cl::Optional,
+                                     cl::desc("Path of the program repository"),
+                                     cl::init("./clang.db"),
+                                     cl::cat(ToolOptions));
+static cl::opt<std::string> TicketPath(cl::Positional,
+                                       cl::desc("<Path of the ticket file>"),
+                                       cl::Required, cl::cat(ToolOptions));
+static cl::list<std::string>
+    Names("names", cl::ZeroOrMore, cl::CommaSeparated,
+          cl::desc("<Compilation member(s) to be displayed>"),
+          cl::cat(ToolOptions));
+static cl::opt<bool> DigestOnly("digest-only", cl::init(false),
+                                cl::desc("Display the digest only"),
+                                cl::cat(ToolOptions));
+static cl::opt<bool>
+    UseComma("comma", cl::init(false),
+             cl::desc("Output fields are comma (rather than CR) separated"),
+             cl::cat(ToolOptions));
+static cl::opt<bool> Verbose("verbose", cl::init(false),
+                             cl::desc("Produce verbose output"),
+                             cl::cat(ToolOptions));
+
+} // anonymous namespace
+
+raw_ostream &operator<<(raw_ostream &OS, pstore::index::digest const &Digest) {
+  return OS << Digest.to_hex_string();
+}
+
+static std::string getRepoPath() {
+  if (RepoPath.getNumOccurrences() == 0) {
+    // TODO: remove this envrionment variable once the matching behavior is
+    // removed from the compiler.
+    if (auto File = getenv("REPOFILE")) {
+      return {File};
+    }
+  }
+  return RepoPath;
+}
+
+int main(int argc, char *argv[]) {
+  cl::HideUnrelatedOptions({&ToolOptions});
+  cl::ParseCommandLineOptions(argc, argv,
+                              "A repo utility for dumping the names and "
+                              "digests using a ticket file.\n");
+
+  ErrorOr<pstore::index::digest> DigestOrError =
+      llvm::repo::getTicketIdFromFile(TicketPath);
+  if (!DigestOrError) {
+    errs() << "Error: '" << TicketPath << "' ("
+           << DigestOrError.getError().message() << ")\n";
+    return EXIT_FAILURE;
+  }
+
+  pstore::index::digest const &Digest = DigestOrError.get();
+  if (Verbose) {
+    outs() << "[ticket file ('" << TicketPath << ")' : \n" << Digest << "]\n\n";
+  }
+
+  pstore::database Db(getRepoPath(), pstore::database::access_mode::read_only);
+  std::shared_ptr<pstore::index::compilation_index const> const
+      CompilationIndex =
+          pstore::index::get_index<pstore::trailer::indices::compilation>(Db);
+  if (!CompilationIndex) {
+    errs() << "Error: compilation index was not found. \n";
+    return EXIT_FAILURE;
+  }
+
+  auto CompilationPos = CompilationIndex->find(Db, Digest);
+  if (CompilationPos == CompilationIndex->end(Db)) {
+    std::string DigestStr;
+    raw_string_ostream SS{DigestStr};
+    SS << Digest;
+    errs() << "Error: compilation " + SS.str() + " was not found.\n";
+    return EXIT_FAILURE;
+  }
+
+  auto Ticket = pstore::repo::compilation::load(Db, CompilationPos->second);
+  if (Verbose) {
+    outs() << "[Compilation]:\n";
+    std::ostringstream out;
+    pstore::dump::value_ptr Output = pstore::dump::make_value(Db, Ticket);
+    Output->write(out);
+    outs() << out.str() << "\n\n";
+  }
+
+  bool IsFirst = true;
+  for (auto const &CM : *Ticket) {
+    if (!IsFirst)
+      outs() << (UseComma ? ',' : '\n');
+    IsFirst = false;
+    assert(CM.name != pstore::typed_address<pstore::indirect_string>::null());
+    const auto Name = pstore::indirect_string::read(Db, CM.name).to_string();
+    if (Names.empty() ||
+        (std::find(Names.begin(), Names.end(), Name) != Names.end())) {
+      if (!DigestOnly)
+        outs() << pstore::indirect_string::read(Db, CM.name).to_string()
+               << ": ";
+      outs() << CM.digest;
+    }
+  }
+  outs() << "\n";
+
+  return EXIT_SUCCESS;
+}

--- a/llvm/utils/repo/docker/build.sh
+++ b/llvm/utils/repo/docker/build.sh
@@ -6,6 +6,7 @@
     --install-target install-pstore \
     --install-target install-repo2obj \
     --install-target install-repo-ticket-dump \
+    --install-target install-repo-fragments \
     --install-target install-clang-resource-headers \
     -- \
     -D CMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
This is a spin-off pull request from #111.

The tool is a little utility for dumping the names and digests from a compilation using its ticket file.