### PR TITLE
Refactoring of RepoFragments.cpp to simplify the main function.

### DIFF
--- a/llvm/tools/repo-fragments/RepoFragments.cpp
+++ b/llvm/tools/repo-fragments/RepoFragments.cpp
@@ -7,12 +7,70 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/MC/MCRepoTicketFile.h"
 #include "llvm/Support/CommandLine.h"
 
-#include "pstore/dump/mcrepo_value.hpp"
+#include "pstore/core/hamt_map.hpp"
+#include "pstore/mcrepo/compilation.hpp"
+
+#include <algorithm>
+#include <limits>
 
 using namespace llvm;
+
+raw_ostream &operator<<(raw_ostream &OS, pstore::index::digest const &Digest) {
+  return OS << Digest.to_hex_string();
+}
+
+static std::string getRepoPath(const cl::opt<std::string> &RepoPath) {
+  if (RepoPath.getNumOccurrences() == 0) {
+    // TODO: remove this environment variable once the matching behavior is
+    // removed from the compiler.
+    if (auto File = getenv("REPOFILE")) {
+      return {File};
+    }
+  }
+  return RepoPath;
+}
+
+// An object which can be used to produce the correct output for a particular
+// name and digest pair from a compilation. The name will be omitted from output
+// if the single-argument ctor is used.
+struct NameAndDigest {
+  explicit NameAndDigest(const pstore::index::digest &Digest)
+      : Digest{Digest} {}
+  NameAndDigest(const StringRef &Name, const pstore::index::digest &Digest)
+      : Name{Name}, Digest{Digest} {}
+
+  Optional<StringRef> Name;
+  pstore::index::digest Digest;
+};
+
+raw_ostream &operator<<(raw_ostream &OS, NameAndDigest const &ND) {
+  if (ND.Name) {
+    OS << *ND.Name << ": ";
+  }
+  OS << ND.Digest;
+  return OS;
+}
+
+// Returns an object that can be written to an ostream to produce the requested
+// output.
+static NameAndDigest makeNameAndDigest(bool DigestOnly, const StringRef &Name,
+                                       pstore::index::digest const &Digest) {
+  if (DigestOnly) {
+    return NameAndDigest{Digest};
+  }
+  return NameAndDigest{Name, Digest};
+};
+
+// Clamps the size_t input value to the maximum unsigned value.
+static constexpr unsigned clamp_to_unsigned(size_t S) {
+  constexpr size_t largest = std::numeric_limits<unsigned>::max();
+  return static_cast<uint16_t>(S > largest ? largest : S);
+}
 
 namespace {
 
@@ -31,29 +89,14 @@ cl::opt<bool>
     UseComma("comma", cl::init(false),
              cl::desc("Output fields are comma (rather than CR) separated"));
 
-} // anonymous namespace
-
-raw_ostream &operator<<(raw_ostream &OS, pstore::index::digest const &Digest) {
-  return OS << Digest.to_hex_string();
-}
-
-static std::string getRepoPath() {
-  if (RepoPath.getNumOccurrences() == 0) {
-    // TODO: remove this envrionment variable once the matching behavior is
-    // removed from the compiler.
-    if (auto File = getenv("REPOFILE")) {
-      return {File};
-    }
-  }
-  return RepoPath;
-}
+} // end anonymous namespace
 
 int main(int argc, char *argv[]) {
   cl::ParseCommandLineOptions(argc, argv,
                               "A utility to dump a compilation's names and "
                               "digests from a program repository.\n");
 
-  ErrorOr<pstore::index::digest> DigestOrError =
+  const ErrorOr<pstore::index::digest> DigestOrError =
       llvm::repo::getTicketIdFromFile(TicketPath);
   if (!DigestOrError) {
     errs() << "Error: '" << TicketPath << "' ("
@@ -61,39 +104,56 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
-  pstore::database Db(getRepoPath(), pstore::database::access_mode::read_only);
+  pstore::database Db{getRepoPath(RepoPath),
+                      pstore::database::access_mode::read_only};
   const auto CompilationIndex =
       pstore::index::get_index<pstore::trailer::indices::compilation>(Db);
   if (!CompilationIndex) {
-    errs() << "Error: compilation index was not found. \n";
+    errs() << "Error: compilation index was not found.\n";
     return EXIT_FAILURE;
   }
 
-  pstore::index::digest const &Digest = DigestOrError.get();
-  auto CompilationPos = CompilationIndex->find(Db, Digest);
+  const auto CompilationPos = CompilationIndex->find(Db, *DigestOrError);
   if (CompilationPos == CompilationIndex->end(Db)) {
-    errs() << "Error: compilation " << Digest << " was not found.\n";
+    errs() << "Error: compilation " << *DigestOrError << " was not found.\n";
     return EXIT_FAILURE;
   }
 
-  auto Compilation =
-      pstore::repo::compilation::load(Db, CompilationPos->second);
-
-  auto *Sep = "";
-  for (auto const &CM : *Compilation) {
-    assert(CM.name != pstore::typed_address<pstore::indirect_string>::null());
-    const auto MemberName =
-        pstore::indirect_string::read(Db, CM.name).to_string();
-    if (Names.empty() ||
-        (std::find(Names.begin(), Names.end(), MemberName) != Names.end())) {
-      outs() << Sep;
-      Sep = (UseComma ? "," : "\n");
-      if (!DigestOnly)
-        outs() << MemberName << ": ";
-      outs() << CM.digest;
-    }
+  // Copy CommandLineNames to a set. This both eliminates any duplicates and
+  // gives us a fast find() function which can quickly determine whether a name
+  // was requested by the user. (Unfortunately, DenseSet<> doesn't support
+  // std::inserter(), so this is a hand-coded loop rather than a call to
+  // std::copy().)
+  DenseSet<StringRef> CommandLineNames{clamp_to_unsigned(Names.size())};
+  for (const std::string &N : Names) {
+    CommandLineNames.insert(N);
   }
-  outs() << "\n";
 
+  // Is 'Name' present in the CommandLineNames set? If CommandLineNames is
+  // empty, then we consider this to be a set containing all names and always
+  // return true.
+  const auto IsRequestedName = [&CommandLineNames](const StringRef &Name) {
+    return CommandLineNames.empty() ||
+           CommandLineNames.find(Name) != std::end(CommandLineNames);
+  };
+
+  const auto *Sep = "";
+  for (auto const &CM :
+       *pstore::repo::compilation::load(Db, CompilationPos->second)) {
+    // Convert the pstore indirect-string to a StringRef. We don't allocate any
+    // unnecessary memory in these steps.
+    pstore::shared_sstring_view Owner;
+    const auto MemberNameView =
+        pstore::indirect_string::read(Db, CM.name).as_db_string_view(&Owner);
+    StringRef MemberNameRef{MemberNameView.data(), MemberNameView.length()};
+
+    // Dump this digest (and perhaps name) if it was requested by the user.
+    if (IsRequestedName(MemberNameRef)) {
+      outs() << Sep << makeNameAndDigest(DigestOnly, MemberNameRef, CM.digest);
+    }
+
+    Sep = UseComma ? "," : "\n";
+  }
+  outs() << '\n';
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This is a follow-up to PR#115. There were a couple of aspects of the code that bothered me a little but were not important enough to justify blocking the additional of the tool. Esp. since the code demonstrably worked!

To elaborate: 

1. The main function contained a loop with a lot of if conditions: deciding whether a definition should be emitted, the character used to separate records, how to display the output.
2. We were performing a linear search of the names specified by the user for each definition in the compilation. That gives us performance of _O(m * n)_ where _m_ is the number of definitions and _n_ is half the number of names specified by the user. Performance isn't likely to be critical for this code, but _m_ could be reasonably large.
3. We were creating instances of std::string when it wasn't really necessary.
