### PR TITLE
The 'names' argument is positional. Add short switches.

### DIFF
--- a/llvm/test/tools/repo-fragments/tool-options-test.ll
+++ b/llvm/test/tools/repo-fragments/tool-options-test.ll
@@ -6,18 +6,20 @@
 ;
 ; RUN: rm -f %t.db
 ; RUN: env REPOFILE=%t.db clang -c --target=x86_64-pc-linux-gnu-repo -x ir %s -o %t.o
-; RUN: env REPOFILE=%t.db repo-fragments %t.o -repo=%t.db | FileCheck --check-prefix=CHECK0 %s
-; RUN: env REPOFILE=%t.db repo-fragments %t.o -names=v -repo=%t.db | FileCheck --check-prefix=CHECK1 %s
-; RUN: env REPOFILE=%t.db repo-fragments %t.o -digest-only -repo=%t.db | FileCheck --check-prefix=CHECK2 %s
-; RUN: env REPOFILE=%t.db repo-fragments %t.o -comma -repo=%t.db | FileCheck --check-prefix=CHECK3 %s
+; RUN: repo-fragments -repo=%t.db %t.o | FileCheck --check-prefix=BASIC %s
+; RUN: repo-fragments -repo=%t.db %t.o v  | FileCheck --check-prefix=VONLY %s
+; RUN: repo-fragments -repo=%t.db -digest-only %t.o | FileCheck --check-prefix=DIGESTONLY %s
+; RUN: repo-fragments -repo=%t.db -d %t.o | FileCheck --check-prefix=DIGESTONLY %s
+; RUN: repo-fragments -repo=%t.db -comma %t.o | FileCheck --check-prefix=COMMA %s
+; RUN: repo-fragments -repo=%t.db -c %t.o | FileCheck --check-prefix=COMMA %s
 ;
-; CHECK0: f: {{([[:xdigit:]]{32})}}
-; CHECK0: v: {{([[:xdigit:]]{32})}}
-; CHECK1-NOT: f: {{([[:xdigit:]]{32})}}
-; CHECK1: v: {{([[:xdigit:]]{32})}}
+; BASIC: f: {{([[:xdigit:]]{32})}}
+; BASIC: v: {{([[:xdigit:]]{32})}}
+; VONLY-NOT: f: {{([[:xdigit:]]{32})}}
+; VONLY: v: {{([[:xdigit:]]{32})}}
+; DIGESTONLY: {{([[:xdigit:]]{32})}}
 ; CHECK2: {{([[:xdigit:]]{32})}}
-; CHECK2: {{([[:xdigit:]]{32})}}
-; CHECK3: f: {{([[:xdigit:]]{32})}},v: {{([[:xdigit:]]{32})}}
+; COMMA: f: {{([[:xdigit:]]{32})}},v: {{([[:xdigit:]]{32})}}
 ;
 target triple = "x86_64-pc-linux-gnu-repo"
 

--- a/llvm/tools/repo-fragments/RepoFragments.cpp
+++ b/llvm/tools/repo-fragments/RepoFragments.cpp
@@ -74,20 +74,22 @@ static constexpr unsigned clamp_to_unsigned(size_t S) {
 
 namespace {
 
-cl::opt<std::string> RepoPath("repo", cl::Optional,
-                              cl::desc("Path of the program repository"),
-                              cl::init("./clang.db"));
 cl::opt<std::string> TicketPath(cl::Positional,
                                 cl::desc("<Path of the ticket file>"),
                                 cl::Required);
 cl::list<std::string>
-    Names("names", cl::ZeroOrMore, cl::CommaSeparated,
+    Names(cl::Positional, cl::ZeroOrMore,
           cl::desc("<Compilation member(s) to be displayed>"));
+cl::opt<std::string> RepoPath("repo", cl::Optional,
+                              cl::desc("Path of the program repository"),
+                              cl::init("./clang.db"));
 cl::opt<bool> DigestOnly("digest-only", cl::init(false),
                          cl::desc("Display the digest only"));
+cl::alias DigestOnly2("d", cl::aliasopt(DigestOnly));
 cl::opt<bool>
     UseComma("comma", cl::init(false),
              cl::desc("Output fields are comma (rather than CR) separated"));
+cl::alias UseComma2("c", cl::aliasopt(UseComma));
 
 } // end anonymous namespace
 


### PR DESCRIPTION
In starting to use the tool in anger I found that I much preferred the switches employed by the original python implementation. That is, the 'names' switch was simply positional arguments listed after the ticket file, and I had single letter aliases for the --digest-only and --comma switches.

Extend the test to cover these new switches. Don't set the REPOFILE environment variable where we're using the --repo switch. Give the FileCheck prefixes meaningful names.