### PR TITLE
Renaming “dependent” sections as “linked_definitions”

### DIFF
--- a/llvm/tools/repo2obj/repo2obj.cpp
+++ b/llvm/tools/repo2obj/repo2obj.cpp
@@ -369,7 +369,7 @@ getELFSectionType(pstore::repo::section_kind Kind,
     REPO_TO_ELF_SECTION(text)
     REPO_TO_ELF_SECTION(thread_bss)
     REPO_TO_ELF_SECTION(thread_data)
-  case pstore::repo::section_kind::dependent:
+  case pstore::repo::section_kind::linked_definitions:
   case pstore::repo::section_kind::last:
     break;
   }

--- a/rld/include/rld/elf.h
+++ b/rld/include/rld/elf.h
@@ -236,7 +236,7 @@ template <typename ELFT> constexpr auto elfSectionType(rld::SectionKind Kind) {
   case SectionKind::shstrtab:
     return Elf_Word{llvm::ELF::SHT_STRTAB};
 
-  case SectionKind::dependent:
+  case SectionKind::linked_definitions:
   case SectionKind::last:
     assert(false); //
     return Elf_Word{};
@@ -284,7 +284,7 @@ template <typename ELFT> constexpr auto elfSectionFlags(SectionKind Kind) {
   case SectionKind::shstrtab:
     return Elf_Word{};
 
-  case SectionKind::dependent:
+  case SectionKind::linked_definitions:
   case SectionKind::last:
     assert(false); //
     return Elf_Word{};
@@ -320,7 +320,7 @@ template <typename ELFT> constexpr auto elfSectionEntSize(SectionKind Kind) {
   case SectionKind::debug_string:
   case SectionKind::debug_ranges:
   case SectionKind::interp:
-  case SectionKind::dependent:
+  case SectionKind::linked_definitions:
   case SectionKind::shstrtab:
   case SectionKind::strtab:
     break;
@@ -342,7 +342,7 @@ ELF_SECTION_NAME(data, ".data");
 ELF_SECTION_NAME(debug_line, ".debug_line");
 ELF_SECTION_NAME(debug_ranges, ".debug_ranges");
 ELF_SECTION_NAME(debug_string, ".debug_str");
-ELF_SECTION_NAME(dependent, "");
+ELF_SECTION_NAME(linked_definitions, "");
 ELF_SECTION_NAME(interp, ".interp");
 ELF_SECTION_NAME(mergeable_1_byte_c_string, ".rodata.str1.1");
 ELF_SECTION_NAME(mergeable_2_byte_c_string, ".rodata.str2.2");

--- a/rld/lib/LayoutBuilder.cpp
+++ b/rld/lib/LayoutBuilder.cpp
@@ -113,7 +113,7 @@ LayoutBuilder::SectionToSegmentArray const LayoutBuilder::SectionToSegment_{{
     {SectionKind::debug_string, SegmentKind::discard},
     {SectionKind::debug_ranges, SegmentKind::discard},
     {SectionKind::interp, SegmentKind::interp},
-    {SectionKind::dependent, SegmentKind::discard},
+    {SectionKind::linked_definitions, SegmentKind::discard},
     {SectionKind::shstrtab, SegmentKind::discard}, // TODO:An unnecessary entry?
                                                    // Use the repo section enum?
     {SectionKind::strtab, SegmentKind::discard},   // TODO:An unnecessary entry?
@@ -212,7 +212,7 @@ inline bool hasFileData(pstore::repo::section_kind Kind) {
         return true;
     case pstore::repo::section_kind::bss:
     case pstore::repo::section_kind::thread_bss:
-    case pstore::repo::section_kind::dependent:
+    case pstore::repo::section_kind::linked_definitions:
     case pstore::repo::section_kind::last:
         return false;
     }
@@ -278,7 +278,7 @@ template <> struct HasFileData<pstore::repo::section_kind::bss> {
 template <> struct HasFileData<pstore::repo::section_kind::thread_bss> {
   static constexpr bool value = false;
 };
-template <> struct HasFileData<pstore::repo::section_kind::dependent> {
+template <> struct HasFileData<pstore::repo::section_kind::linked_definitions> {
   static constexpr bool value = false;
 };
 template <> struct HasFileData<pstore::repo::section_kind::last> {

--- a/rld/lib/XfxScanner.cpp
+++ b/rld/lib/XfxScanner.cpp
@@ -93,7 +93,7 @@ void resolve(State &S, FragmentAddress FAddr,
 }
 
 template <>
-inline void resolve<pstore::repo::section_kind::dependent>(
+inline void resolve<pstore::repo::section_kind::linked_definitions>(
     State & /*S*/,
     pstore::typed_address<pstore::repo::fragment> /*FragmentAddress*/,
     const pstore::repo::fragment & /*Fragment*/) {}

--- a/rld/lib/copy.cpp
+++ b/rld/lib/copy.cpp
@@ -63,9 +63,8 @@ void copySection<pstore::repo::section_kind::bss>(Context &Ctxt,
 }
 
 template <>
-void copySection<pstore::repo::section_kind::dependent>(Context &,
-                                                        Contribution const &,
-                                                        std::uint8_t *) {
+void copySection<pstore::repo::section_kind::linked_definitions>(
+    Context &, Contribution const &, std::uint8_t *) {
   // discard
 }
 

--- a/rld/lib/elf.cpp
+++ b/rld/lib/elf.cpp
@@ -77,7 +77,7 @@ ELF_SECTION_NAME(debug_ranges, ".debug_ranges");
 ELF_SECTION_NAME(interp, ".interp");
 ELF_SECTION_NAME(shstrtab, ".shstrtab");
 ELF_SECTION_NAME(strtab, ".strtab");
-ELF_SECTION_NAME(dependent, "");
+ELF_SECTION_NAME(linked_definitions, "");
 
 #undef ELF_SECTION_NAME
 

--- a/rld/tools/gen/FragmentCreator.cpp
+++ b/rld/tools/gen/FragmentCreator.cpp
@@ -126,8 +126,8 @@ auto FragmentCreator::createDispatcher<pstore::repo::section_kind::debug_line>()
 }
 
 template <>
-auto FragmentCreator::createDispatcher<pstore::repo::section_kind::dependent>()
-    -> DispatcherPtr {
+auto FragmentCreator::createDispatcher<
+    pstore::repo::section_kind::linked_definitions>() -> DispatcherPtr {
   return {};
 }
 
@@ -148,7 +148,7 @@ void FragmentCreator::setDispatcherContent<
 
 template <>
 void FragmentCreator::setDispatcherContent<
-    pstore::repo::section_kind::dependent>(
+    pstore::repo::section_kind::linked_definitions>(
     pstore::repo::section_creation_dispatcher *,
     pstore::repo::section_content const *) {}
 


### PR DESCRIPTION
The change is intended to avoid confusion between the use of the term “dependents” in the context of repository hash generation and the storage of definitions created as a result of global optimization here. It matches the code to the terminology documented on [this wiki page](https://github.com/SNSystems/llvm-project-prepo/wiki/Dealing-with-the-Effects-of-Global-Optimisations).

Note that this PR is paired with an [equivalent PR](https://github.com/SNSystems/pstore/pull/69) in pstore. That PR changes the pstore API: this updates LLVM to use the newer names.

