### PR TITLE
Unify the code for ticket files and finalise their contents.

### DIFF
--- a/llvm/include/llvm/MC/MCRepoTicketFile.h
+++ b/llvm/include/llvm/MC/MCRepoTicketFile.h
@@ -10,13 +10,19 @@
 #ifndef LLVM_MC_MCREPOTICKETFILE_H
 #define LLVM_MC_MCREPOTICKETFILE_H
 
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/EndianStream.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorOr.h"
+
+#include "pstore/core/uuid.hpp"
+#include "pstore/support/uint128.hpp"
+
 #include <system_error>
 
 namespace pstore {
-class uint128;
+class database;
 namespace index {
 using digest = uint128;
 } // end namespace index
@@ -26,29 +32,94 @@ namespace llvm {
 class raw_ostream;
 class MemoryBufferRef;
 
+namespace mc {
 namespace repo {
 
 extern const uint64_t TicketFileSize;
 
 const std::error_category &ticketErrorCategory();
-enum class TicketError { CorruptedTicket = 1 };
+enum class TicketError { CorruptedTicket = 1, DatabaseIDMismatch };
 inline std::error_code make_error_code(TicketError E) {
   return {static_cast<int>(E), ticketErrorCategory()};
 }
 
-void writeTicketFile(support::endian::Writer &W,
-                     pstore::index::digest const &Digest);
+/// Write a ticket file to an endian Writer instance.
+///
+/// \param W The Writer to which to ticket file should be written.
+/// \param Db  The database which owns the digest contained within the ticket
+///   file.
+/// \param Digest  The digest of a compilation contained with the database given
+///   by \p Db.
+void writeTicketFile(support::endian::Writer &&W, const pstore::database &Db,
+                     const pstore::index::digest &Digest);
 
-ErrorOr<pstore::index::digest> getTicketId(llvm::MemoryBufferRef const & Buffer);
-ErrorOr<pstore::index::digest> getTicketIdFromFile(StringRef TicketPath);
+/// Write a ticket file to an endian Writer instance.
+///
+/// \param W The Writer to which to ticket file should be written.
+/// \param Db  The database which owns the digest contained within the ticket
+///   file.
+/// \param Digest  The digest of a compilation contained with the database given
+///   by \p Db.
+void writeTicketFile(support::endian::Writer &W, const pstore::database &Db,
+                     const pstore::index::digest &Digest);
+
+/// Write a ticket file to supplied path.
+///
+/// \param Path The path of the ticket file to be written.
+/// \param Db  The database which owns the digest contained within the ticket
+///   file.
+/// \param Digest  The digest of a compilation contained with the database given
+///   by \p Db.
+Error writeTicketFile(const llvm::StringRef &Path, const pstore::database &Db,
+                      const pstore::index::digest &Digest);
+
+/// Given an in-memory ticket, returns the digest that it contains. An optional
+/// database instance can be passed. If supplied, the function checks that the
+/// ticket reference this database and will yield an error if not.
+///
+/// \param Buffer  A memory buffer containing a ticket.
+/// \param Owner  If non-null, the function verifies that the ticket is owned by
+///   this database. If this check fails, an error is returned. If null, this
+///   check is bypassed.
+/// \returns  The index digest containing within the ticket or an error.
+ErrorOr<pstore::index::digest>
+getDigestFromTicket(const llvm::MemoryBufferRef &Buffer,
+                    pstore::database const *Owner);
+
+/// Returns the index digest contained within the ticket file at the given path.
+/// An optional database instance can be passed. If supplied, the function
+/// checks that the ticket reference this database and will yield an error if
+/// not.
+///
+/// \param TicketPath  The path of a ticket file.
+/// \param Owner  If non-null, the function verifies that the ticket is owned by
+///   this database. If this check fails, an error is returned. If null, this
+///   check is bypassed.
+/// \returns  The index digest containing within the ticket or an error.
+ErrorOr<pstore::index::digest>
+getDigestFromTicket(StringRef TicketPath, pstore::database const *Owner);
+
+/// Given an in-memory ticket, returns the ID of the database by which it is
+/// "owned".
+///
+/// \param Buffer  A memory buffer containing a ticket.
+/// \returns  The ID of the owning database or an error.
+ErrorOr<pstore::uuid> getOwnerIDFromTicket(const llvm::MemoryBufferRef &Buffer);
+
+/// Returns the ID of the database which owns the ticket at the given path.
+///
+/// \param TicketPath  The path of a ticket file.
+/// \returns  The ID of the owning database or an error.
+ErrorOr<pstore::uuid> getOwnerIDFromTicket(StringRef TicketPath);
 
 } // end namespace repo
+} // end namespace mc
 } // end namespace llvm
 
 namespace std {
 
 template <>
-struct is_error_code_enum<llvm::repo::TicketError> : std::true_type {};
+struct is_error_code_enum<llvm::mc::repo::TicketError> : std::true_type {};
 
 } // end namespace std
 

--- a/llvm/lib/MC/MCRepoTicketFile.cpp
+++ b/llvm/lib/MC/MCRepoTicketFile.cpp
@@ -10,113 +10,304 @@
 #include "llvm/MC/MCRepoTicketFile.h"
 
 #include "pstore/core/index_types.hpp"
+#include "pstore/core/database.hpp"
+
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CRC.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <array>
+#include <type_traits>
 
 using namespace llvm;
-using namespace repo;
 
 namespace {
+
 static constexpr auto MagicSize = size_t{8};
 static const std::array<char, MagicSize> BERepoMagic{
     {'R', 'e', 'p', 'o', 'T', 'c', 'k', 't'}};
 static const std::array<char, MagicSize> LERepoMagic{
     {'t', 'k', 'c', 'T', 'o', 'p', 'e', 'R'}};
 
-class TicketErrorCategoryType final : public std::error_category {
+class TicketErrorCategory final : public std::error_category {
   const char *name() const noexcept override { return "llvm.repo.ticket"; }
 
   std::string message(int IE) const override {
-    switch (static_cast<llvm::repo::TicketError>(IE)) {
-    case llvm::repo::TicketError::CorruptedTicket:
+    switch (static_cast<mc::repo::TicketError>(IE)) {
+    case mc::repo::TicketError::CorruptedTicket:
       return "Corrupted Ticket File";
+    case mc::repo::TicketError::DatabaseIDMismatch:
+      return "Database ID mismatch";
     }
     llvm_unreachable("Unknown error type!");
   }
 };
-} // anonymous namespace
 
-const uint64_t llvm::repo::TicketFileSize = MagicSize + sizeof(pstore::index::digest);
+struct TicketFile {
+  std::array<char, MagicSize> Magic;
+  uint32_t CRC;
+  uint16_t Version;
+  uint16_t Unused;
+  pstore::uuid OwnerID;
+  pstore::index::digest Digest;
+};
 
-const std::error_category &llvm::repo::ticketErrorCategory() {
-  static TicketErrorCategoryType Category;
+constexpr uint16_t TicketFileVersion = 1;
+
+// Verify that the compiler used the expected structure layout so that the
+// on-disk representation will be consistent between different machines.
+static_assert(sizeof(TicketFile) == 48, "Expected TicketFile to be 48 bytes");
+static_assert(std::is_standard_layout<TicketFile>::value,
+              "TicketFile must be StandardLayout");
+static_assert(offsetof(TicketFile, Magic) == 0,
+              "Expected Magic to be at offset 0");
+static_assert(offsetof(TicketFile, CRC) == 8, "Expected CRC to be at offset 8");
+static_assert(offsetof(TicketFile, Version) == 12,
+              "Expected Version to be at offset 12");
+static_assert(offsetof(TicketFile, Unused) == 14,
+              "Expected Unused to be at offset 14");
+static_assert(offsetof(TicketFile, OwnerID) == 16,
+              "Expected OwnerID to be at offset 16");
+static_assert(offsetof(TicketFile, Digest) == 32,
+              "Expected Digest to be at offset 32");
+
+class ScopedFD {
+public:
+  ScopedFD() = default;
+  explicit ScopedFD(int Descriptor) : FD_{Descriptor} {}
+  ScopedFD(const ScopedFD &) = delete;
+  ScopedFD(ScopedFD &&Other) {
+    if (Other.FD_) {
+      FD_ = *Other.FD_;
+      Other.FD_.reset();
+    }
+  }
+  ~ScopedFD() {
+    if (FD_) {
+      sys::Process::SafelyCloseFileDescriptor(*FD_);
+    }
+  }
+
+  explicit operator bool() const { return FD_.hasValue(); }
+  bool hasValue() const { return FD_.hasValue(); }
+  int getValue() const { return FD_.getValue(); }
+
+  ScopedFD &operator=(const ScopedFD &) = delete;
+  ScopedFD &operator=(ScopedFD &&Other) {
+    if (Other.FD_) {
+      FD_ = *Other.FD_;
+      Other.FD_.reset();
+    } else {
+      FD_.reset();
+    }
+    return *this;
+  }
+
+private:
+  Optional<int> FD_;
+};
+
+} // end anonymous namespace
+
+namespace pstore {
+
+inline uint128 getSwappedBytes(uint128 const &V) {
+  return {sys::getSwappedBytes(V.low()), sys::getSwappedBytes(V.high())};
+}
+
+} // end namespace pstore
+
+const uint64_t llvm::mc::repo::TicketFileSize = sizeof(TicketFile);
+
+const std::error_category &llvm::mc::repo::ticketErrorCategory() {
+  static TicketErrorCategory Category;
   return Category;
 }
 
-void llvm::repo::writeTicketFile(support::endian::Writer &W,
-                                 pstore::index::digest const &Digest) {
-  std::array<char, MagicSize> const *Signature;
-  std::uint64_t Out[2];
+template <typename Writer, typename T>
+static size_t write(Writer &&W, const T *Data, size_t Elements) {
+  const auto Size = Elements * sizeof(T);
+  W.OS.write(reinterpret_cast<const char *>(Data), Size);
+  return Size;
+}
 
-  if (W.Endian == support::little) {
-    Signature = &LERepoMagic;
-    support::endian::write64le(&Out[0], Digest.low());
-    support::endian::write64le(&Out[1], Digest.high());
+template <typename Writer>
+static size_t
+writeTicketFileImpl(Writer &&W, const std::array<char, MagicSize> &Signature,
+                    const std::array<uint64_t, 2> &SwappedID,
+                    const std::array<uint64_t, 2> &SwappedDigest) {
+
+  auto BytesWritten = write(W, Signature.data(), Signature.size());
+  BytesWritten += write(W, SwappedID.data(), SwappedID.size());
+  BytesWritten += write(W, SwappedDigest.data(), SwappedDigest.size());
+  return BytesWritten;
+}
+
+static uint32_t ticketCRC(const TicketFile &T) {
+  const auto *Base =
+      reinterpret_cast<const uint8_t *>(&T) + offsetof(TicketFile, Version);
+  const size_t Size = sizeof(TicketFile) - offsetof(TicketFile, Version);
+  return crc32(ArrayRef<uint8_t>{Base, Size});
+}
+
+template <typename Writer>
+static size_t writeTicketFile(Writer &&W, const pstore::database &Db,
+                              const pstore::index::digest &Digest) {
+  const support::endianness Endian = W.Endian == support::native
+                                         ? support::endian::system_endianness()
+                                         : W.Endian;
+  assert(Endian == support::little || Endian == support::big);
+
+  TicketFile Ticket;
+  Ticket.Magic = (W.Endian == support::little) ? LERepoMagic : BERepoMagic;
+  Ticket.CRC = 0;
+  Ticket.Version = support::endian::byte_swap(TicketFileVersion, Endian);
+  Ticket.Unused = 0;
+  Ticket.OwnerID = Db.get_header().id(); // No need to swap. OwnerID is a UUID
+                                         // whose bytes are in network order.
+  Ticket.Digest = support::endian::byte_swap(Digest, Endian);
+
+  Ticket.CRC = support::endian::byte_swap(ticketCRC(Ticket), Endian);
+  W.OS.write(reinterpret_cast<const char *>(&Ticket), sizeof(Ticket));
+  return sizeof(Ticket);
+}
+
+void llvm::mc::repo::writeTicketFile(support::endian::Writer &&W,
+                                     const pstore::database &Db,
+                                     const pstore::index::digest &Digest) {
+  const auto BytesWritten = ::writeTicketFile(W, Db, Digest);
+  (void)BytesWritten;
+  assert(BytesWritten == TicketFileSize &&
+         "TicketFileSize did not match bytes written!");
+}
+
+void llvm::mc::repo::writeTicketFile(support::endian::Writer &W,
+                                     const pstore::database &Db,
+                                     const pstore::index::digest &Digest) {
+  const auto BytesWritten = ::writeTicketFile(W, Db, Digest);
+  (void)BytesWritten;
+  assert(BytesWritten == TicketFileSize &&
+         "TicketFileSize did not match bytes written!");
+}
+
+Error llvm::mc::repo::writeTicketFile(const llvm::StringRef &Path,
+                                      const pstore::database &Db,
+                                      const pstore::index::digest &Digest) {
+  std::error_code EC;
+  llvm::raw_fd_ostream OutFile{Path, EC};
+  if (EC) {
+    return errorCodeToError(EC);
+  }
+  writeTicketFile(
+      llvm::support::endian::Writer{OutFile, llvm::support::endianness::native},
+      Db, Digest);
+  return errorCodeToError(OutFile.error());
+}
+
+static ErrorOr<TicketFile> getTicket(const llvm::MemoryBufferRef &Buffer,
+                                     pstore::database const *const Owner) {
+  const StringRef Contents = Buffer.getBuffer();
+  assert(mc::repo::TicketFileSize == sizeof(TicketFile) &&
+         "TicketFileSize must be sizeof(TicketFile)");
+  if (Contents.size() != sizeof(TicketFile)) {
+    return mc::repo::TicketError::CorruptedTicket;
+  }
+
+  TicketFile Ticket = *reinterpret_cast<const TicketFile *>(Contents.data());
+
+  support::endianness Endian;
+  if (Ticket.Magic == LERepoMagic) {
+    Endian = support::little;
+  } else if (Ticket.Magic == BERepoMagic) {
+    Endian = support::big;
   } else {
-    Signature = &BERepoMagic;
-    support::endian::write64be(&Out[0], Digest.high());
-    support::endian::write64be(&Out[1], Digest.low());
+    return mc::repo::TicketError::CorruptedTicket;
   }
 
-  W.OS.write(Signature->data(), Signature->size());
-  W.OS.write(reinterpret_cast<const char *>(Out), sizeof(Out));
+  const uint32_t ExpectedCRC = ticketCRC(Ticket);
+
+  Ticket.CRC = support::endian::byte_swap(Ticket.CRC, Endian);
+  Ticket.Version = support::endian::byte_swap(Ticket.Version, Endian);
+  Ticket.Digest = support::endian::byte_swap(Ticket.Digest, Endian);
+
+  if (Ticket.Version != TicketFileVersion || Ticket.CRC != ExpectedCRC) {
+    return mc::repo::TicketError::CorruptedTicket;
+  }
+
+  if (Owner != nullptr) {
+    if (Ticket.OwnerID != Owner->get_header().id()) {
+      return mc::repo::TicketError::DatabaseIDMismatch;
+    }
+  }
+  return Ticket;
 }
 
-ErrorOr<pstore::index::digest>
-llvm::repo::getTicketId(llvm::MemoryBufferRef const & Buffer) {
-  StringRef const Contents = Buffer.getBuffer();
-  if (Contents.size () != TicketFileSize) {
-    return std::error_code(TicketError::CorruptedTicket);
-  }
-
-  std::array<char, MagicSize> Signature;
-  std::copy_n(std::begin(Contents), MagicSize, std::begin(Signature));
-
-  if (Signature == LERepoMagic) {
-    auto const Low = Contents.data() + MagicSize;
-    auto const High = Low + sizeof(std::uint64_t);
-    return {pstore::index::digest{support::endian::read64le(High),
-                                  support::endian::read64le(Low)}};
-  } else if (Signature == BERepoMagic) {
-    auto const High = Contents.data() + MagicSize;
-    auto const Low = High + sizeof(std::uint64_t);
-    return {pstore::index::digest{support::endian::read64be(High),
-                                  support::endian::read64be(Low)}};
-  }
-  return std::error_code(TicketError::CorruptedTicket);
-}
-
-ErrorOr<pstore::index::digest>
-llvm::repo::getTicketIdFromFile(StringRef TicketPath) {
-  int TicketFD = 0;
-  if (std::error_code Err = sys::fs::openFileForRead(TicketPath, TicketFD)) {
+static ErrorOr<ScopedFD> openFile(StringRef Path) {
+  int FD = 0;
+  if (const std::error_code Err = sys::fs::openFileForRead(Path, FD)) {
     return Err;
   }
+  return ScopedFD{FD};
+}
 
+static ErrorOr<std::unique_ptr<MemoryBuffer>>
+openTicketFile(StringRef TicketPath) {
+  const auto FDOrErr = openFile(TicketPath);
+  if (!FDOrErr) {
+    return FDOrErr.getError();
+  }
+  const int FD = FDOrErr->getValue();
   sys::fs::file_status Status;
-  if (std::error_code Err = sys::fs::status(TicketFD, Status)) {
+  if (const std::error_code Err = sys::fs::status(FD, Status)) {
     return Err;
   }
-  uint64_t const FileSize = Status.getSize();
-  if (FileSize != TicketFileSize) {
-    return std::error_code(TicketError::CorruptedTicket);
+  const uint64_t FileSize = Status.getSize();
+  if (FileSize != mc::repo::TicketFileSize) {
+    return mc::repo::TicketError::CorruptedTicket;
   }
 
-  ErrorOr<std::unique_ptr<MemoryBuffer>> MemberBufferOrErr =
-      MemoryBuffer::getOpenFile(sys::fs::convertFDToNativeFile(TicketFD),
-                                TicketPath, FileSize, false);
-  if (!MemberBufferOrErr) {
-    return MemberBufferOrErr.getError();
-  }
+  return MemoryBuffer::getOpenFile(sys::fs::convertFDToNativeFile(FD),
+                                   TicketPath, FileSize, false);
+}
 
-  if (auto Err = sys::Process::SafelyCloseFileDescriptor(TicketFD)) {
-    return Err;
+ErrorOr<pstore::index::digest>
+llvm::mc::repo::getDigestFromTicket(const llvm::MemoryBufferRef &Buffer,
+                                    const pstore::database *const Owner) {
+  const ErrorOr<TicketFile> TicketOrErr = getTicket(Buffer, Owner);
+  if (!TicketOrErr) {
+    return TicketOrErr.getError();
   }
+  return TicketOrErr->Digest;
+}
 
-  return getTicketId (**MemberBufferOrErr);
+ErrorOr<pstore::index::digest>
+llvm::mc::repo::getDigestFromTicket(StringRef TicketPath,
+                                    pstore::database const *const Owner) {
+  const auto MemoryBufferOrErr = openTicketFile(TicketPath);
+  if (!MemoryBufferOrErr) {
+    return MemoryBufferOrErr.getError();
+  }
+  return getDigestFromTicket(**MemoryBufferOrErr, Owner);
+}
+
+ErrorOr<pstore::uuid>
+llvm::mc::repo::getOwnerIDFromTicket(const llvm::MemoryBufferRef &Buffer) {
+  const ErrorOr<TicketFile> TicketOrErr = getTicket(Buffer, nullptr);
+  if (!TicketOrErr) {
+    return TicketOrErr.getError();
+  }
+  return TicketOrErr->OwnerID;
+}
+
+ErrorOr<pstore::uuid>
+llvm::mc::repo::getOwnerIDFromTicket(StringRef TicketPath) {
+  const auto MemoryBufferOrErr = openTicketFile(TicketPath);
+  if (!MemoryBufferOrErr) {
+    return MemoryBufferOrErr.getError();
+  }
+  return getOwnerIDFromTicket(**MemoryBufferOrErr);
 }

--- a/llvm/lib/MC/RepoObjectWriter.cpp
+++ b/llvm/lib/MC/RepoObjectWriter.cpp
@@ -1080,7 +1080,7 @@ uint64_t RepoObjectWriter::writeObject(MCAssembler &Asm,
   }
 
   // write the ticket file itself
-  llvm::repo::writeTicketFile(W, TicketDigest);
+  llvm::mc::repo::writeTicketFile(W, Db, TicketDigest);
 
   return W.OS.tell() - StartOffset;
 }

--- a/llvm/test/tools/repo-fragments/wrong-database.ll
+++ b/llvm/test/tools/repo-fragments/wrong-database.ll
@@ -1,0 +1,18 @@
+; Compile to two different databases. Run repo-fragments with a ticket
+; associated with one database but specifying the other to ensure that it
+; returns failure.
+;
+; RUN: rm -rf %t && mkdir -p %t
+;
+; RUN: env REPOFILE=%t/db1.db clang -c -x ir %s -o %t/ticket1.o
+; RUN: env REPOFILE=%t/db2.db clang -c -x ir %s -o %t/ticket2.o
+; RUN: repo-fragments -repo=%t/db1.db %t/ticket1.o
+; RUN: not repo-fragments -repo=%t/db2.db %t/ticket1.o
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+define void @f() {
+entry:
+  ret void
+}
+

--- a/llvm/test/tools/repo-fragments/wrong-database.ll
+++ b/llvm/test/tools/repo-fragments/wrong-database.ll
@@ -4,12 +4,10 @@
 ;
 ; RUN: rm -rf %t && mkdir -p %t
 ;
-; RUN: env REPOFILE=%t/db1.db clang -c -x ir %s -o %t/ticket1.o
-; RUN: env REPOFILE=%t/db2.db clang -c -x ir %s -o %t/ticket2.o
+; RUN: env REPOFILE=%t/db1.db clang -c -x ir -target x86_64-pc-linux-gnu-repo %s -o %t/ticket1.o
+; RUN: env REPOFILE=%t/db2.db clang -c -x ir -target x86_64-pc-linux-gnu-repo %s -o %t/ticket2.o
 ; RUN: repo-fragments -repo=%t/db1.db %t/ticket1.o
 ; RUN: not repo-fragments -repo=%t/db2.db %t/ticket1.o
-
-target triple = "x86_64-pc-linux-gnu-repo"
 
 define void @f() {
 entry:

--- a/llvm/test/tools/repo2obj/wrong-database.ll
+++ b/llvm/test/tools/repo2obj/wrong-database.ll
@@ -1,0 +1,18 @@
+; Compile to two different databases. Run repo2obj with a ticket
+; associated with one database but specifying the other to ensure that it
+; returns failure.
+;
+; RUN: rm -rf %t && mkdir -p %t
+;
+; RUN: env REPOFILE=%t/db1.db clang -c -x ir %s -o %t/ticket1.o
+; RUN: env REPOFILE=%t/db2.db clang -c -x ir %s -o %t/ticket2.o
+; RUN: repo2obj --repo=%t/db1.db %t/ticket1.o
+; RUN: not repo2obj --repo=%t/db2.db %t/ticket1.o
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+define void @f() {
+entry:
+  ret void
+}
+

--- a/llvm/test/tools/repo2obj/wrong-database.ll
+++ b/llvm/test/tools/repo2obj/wrong-database.ll
@@ -4,12 +4,10 @@
 ;
 ; RUN: rm -rf %t && mkdir -p %t
 ;
-; RUN: env REPOFILE=%t/db1.db clang -c -x ir %s -o %t/ticket1.o
-; RUN: env REPOFILE=%t/db2.db clang -c -x ir %s -o %t/ticket2.o
+; RUN: env REPOFILE=%t/db1.db clang -c -x ir -target x86_64-pc-linux-gnu-repo %s -o %t/ticket1.o
+; RUN: env REPOFILE=%t/db2.db clang -c -x ir -target x86_64-pc-linux-gnu-repo %s -o %t/ticket2.o
 ; RUN: repo2obj --repo=%t/db1.db %t/ticket1.o
 ; RUN: not repo2obj --repo=%t/db2.db %t/ticket1.o
-
-target triple = "x86_64-pc-linux-gnu-repo"
 
 define void @f() {
 entry:

--- a/llvm/tools/repo-fragments/RepoFragments.cpp
+++ b/llvm/tools/repo-fragments/RepoFragments.cpp
@@ -64,7 +64,7 @@ static NameAndDigest makeNameAndDigest(bool DigestOnly, const StringRef &Name,
     return NameAndDigest{Digest};
   }
   return NameAndDigest{Name, Digest};
-};
+}
 
 // Clamps the size_t input value to the maximum unsigned value.
 static constexpr unsigned clamp_to_unsigned(size_t S) {
@@ -98,16 +98,17 @@ int main(int argc, char *argv[]) {
                               "A utility to dump a compilation's names and "
                               "digests from a program repository.\n");
 
+  pstore::database Db{getRepoPath(RepoPath),
+                      pstore::database::access_mode::read_only};
+
   const ErrorOr<pstore::index::digest> DigestOrError =
-      llvm::repo::getTicketIdFromFile(TicketPath);
+      mc::repo::getDigestFromTicket(TicketPath, &Db);
   if (!DigestOrError) {
     errs() << "Error: '" << TicketPath << "' ("
            << DigestOrError.getError().message() << ")\n";
     return EXIT_FAILURE;
   }
 
-  pstore::database Db{getRepoPath(RepoPath),
-                      pstore::database::access_mode::read_only};
   const auto CompilationIndex =
       pstore::index::get_index<pstore::trailer::indices::compilation>(Db);
   if (!CompilationIndex) {

--- a/llvm/tools/repo-ticket-dump/RepoTicketDump.cpp
+++ b/llvm/tools/repo-ticket-dump/RepoTicketDump.cpp
@@ -1,4 +1,14 @@
+//===- repo-ticket-dump - Dump the contents of a prepo ticket file. -------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
 #include "pstore/core/index_types.hpp"
+
 #include "llvm/MC/MCRepoTicketFile.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
@@ -7,10 +17,17 @@ using namespace llvm;
 
 namespace {
 
-cl::opt<std::string> TicketPath(cl::Positional, cl::desc("<ticket path>"), cl::Optional,
-                                cl::init("./a.out"));
+cl::opt<bool> DatabaseId{
+    "database-id",
+    cl::desc("Dump the ID of the database associated with the ticket rather "
+             "than the compilation digest"),
+    cl::init(false)};
+cl::alias DatabaseId2{"I", cl::aliasopt(DatabaseId)};
 
-} // anonymous namespace
+cl::opt<std::string> TicketPath{cl::Positional, cl::desc("<ticket path>"),
+                                cl::Optional, cl::init("./a.out")};
+
+} // end anonymous namespace
 
 raw_ostream &operator<<(raw_ostream &OS, pstore::index::digest const &Digest) {
   return OS << Digest.to_hex_string();
@@ -19,14 +36,27 @@ raw_ostream &operator<<(raw_ostream &OS, pstore::index::digest const &Digest) {
 int main(int argc, char *argv[]) {
   cl::ParseCommandLineOptions(argc, argv);
 
-  ErrorOr<pstore::index::digest> DigestOrError =
-      llvm::repo::getTicketIdFromFile(TicketPath);
-  if (!DigestOrError) {
+  if (DatabaseId) {
+    const ErrorOr<pstore::uuid> IDOrErr =
+        mc::repo::getOwnerIDFromTicket(TicketPath);
+    if (!IDOrErr) {
+      errs() << "Error: '" << TicketPath << "' ("
+             << IDOrErr.getError().message() << ")\n";
+      return EXIT_FAILURE;
+    }
+
+    outs() << pstore::uuid{IDOrErr.get()}.str() << '\n';
+    return EXIT_SUCCESS;
+  }
+
+  ErrorOr<pstore::index::digest> DigestOrErr =
+      mc::repo::getDigestFromTicket(TicketPath, nullptr);
+  if (!DigestOrErr) {
     errs() << "Error: '" << TicketPath << "' ("
-           << DigestOrError.getError().message() << ")\n";
+           << DigestOrErr.getError().message() << ")\n";
     return EXIT_FAILURE;
   }
 
-  outs() << DigestOrError.get() << '\n';
+  outs() << DigestOrErr.get() << '\n';
   return EXIT_SUCCESS;
 }

--- a/rld/lib/Identify.cpp
+++ b/rld/lib/Identify.cpp
@@ -182,7 +182,7 @@ std::pair<bool, size_t> rld::Identifier::addFile(const Twine &Path,
 bool rld::Identifier::addTicketFile(const Twine &Name, MemoryBufferRef Memory,
                                     const Ordinals &Ord, bool InArchive) {
   ErrorOr<pstore::index::digest> CompilationDigestOrError =
-      repo::getTicketId(Memory);
+      mc::repo::getDigestFromTicket(Memory, &Db_);
   if (!CompilationDigestOrError) {
     return this->error([&](raw_ostream &OS) {
       OS << "File \"" << Name << "\". "
@@ -276,15 +276,15 @@ rld::Identifier::addArchiveContents(const Twine &ArchivePath,
 // ~~~~~~~~~~~
 auto rld::Identifier::getFileKind(MemoryBufferRef Memory) -> ErrorOr<FileKind> {
   // TODO: teach identify_magic about repo ticket files.
-  if (Memory.getBufferSize() == repo::TicketFileSize) {
+  if (Memory.getBufferSize() == mc::repo::TicketFileSize) {
     // It might be a ticket file.
     const ErrorOr<pstore::index::digest> DigestOrError =
-        repo::getTicketId(Memory);
+        mc::repo::getDigestFromTicket(Memory, nullptr);
     if (DigestOrError) {
       return FileKind::Ticket;
     }
     if (DigestOrError.getError() !=
-        make_error_code(repo::TicketError::CorruptedTicket)) {
+        make_error_code(mc::repo::TicketError::CorruptedTicket)) {
       return DigestOrError.getError();
     }
   }

--- a/rld/tools/gen/CMakeLists.txt
+++ b/rld/tools/gen/CMakeLists.txt
@@ -46,13 +46,18 @@ set (XXHASH_BUILD_ENABLE_INLINE_API OFF) #optional
 set (XXHASH_BUILD_XXHSUM OFF) #optional
 add_subdirectory (xxHash/cmake_unofficial EXCLUDE_FROM_ALL)
 
+set(LLVM_LINK_COMPONENTS
+  MC
+  Support
+)
+
 add_llvm_tool (rld-gen
   gen.cpp
   fibonacci.hpp
   hash.h
   FragmentCreator.cpp
 )
-target_link_libraries (rld-gen PRIVATE LLVMSupport pstore-core pstore-mcrepo)
+target_link_libraries (rld-gen PRIVATE pstore-core pstore-mcrepo)
 target_link_libraries (rld-gen PRIVATE xxHash::xxhash)
 
 set_target_properties (rld-gen PROPERTIES


### PR DESCRIPTION
There is now a single module which understands the format of ticket files and can read and write them. Extend the file contents so that it includes a version number, CRC, and owning database ID. Extend the tools so that the owning database ID is checked and add tests to ensure that an error is issued if a mismatch is found.

The intent of this work is to enable me to write a tool that will create a ticket file when given a database and a compilation digest. This (in conjunction with pstore-import that was added by [pstore PR #70](https://github.com/SNSystems/pstore/pull/70)) will then enable proper tests to be written for the post-compiler tools (e.g. repo2obj and rld).

This change will resolve issue #69.