### PR TITLE
Fixing an undefined reference error which is caused by incorrect hash calculation.

### DIFF
--- a/llvm/include/llvm/IR/RepoHashCalculator.h
+++ b/llvm/include/llvm/IR/RepoHashCalculator.h
@@ -178,18 +178,21 @@ public:
 
   repodefinition::GOVec &getDependencies() { return Dependencies; }
 
-  repodefinition::GOVec &getContributedToGVs() { return ContributedToGVs; }
+  repodefinition::GOVec &getContributions() { return Contributions; }
 
 private:
-  // Accumulate the hash of basicblocks, instructions and variables etc in the
-  // function Fn.
+  /// Accumulate the hash of basicblocks, instructions and variables etc in the
+  /// function Fn.
   MD5 Hash;
 
-  // Vector of global objects which the function/variable references.
-  repodefinition::GOVec Dependencies;
+  /// The Contributions of an object (X) are those objects (Y) which
+  /// transitively reference X and where a potential optimisation to either X or
+  /// any of Y may invalidate both.
+  repodefinition::GOVec Contributions;
 
-  // Vector of global objects to which the function/variable has contributed.
-  repodefinition::GOVec ContributedToGVs;
+  /// The Dependencies of an object are those objects which it transitively
+  /// references but are not Contributions.
+  repodefinition::GOVec Dependencies;
 
   /// Assign serial numbers to values from the function.
   /// Explanation:
@@ -304,19 +307,6 @@ private:
 
   // Hold the function hash value.
   HashCalculator FnHash;
-
-  template <typename T>
-  void addContributedToGVsFromCallInvoke(const T *Instruction) {
-    for (unsigned i = 0, ie = Instruction->getNumArgOperands(); i != ie; ++i) {
-      if (auto *GV = getAddressFromValue(Instruction->getArgOperand(i))) {
-        FnHash.getContributedToGVs().emplace_back(GV);
-      }
-    }
-  }
-
-  const GlobalVariable *getAddressFromConstant(const Constant *C);
-  const GlobalVariable *getAddressFromValue(const Value *V);
-  const GlobalVariable *getStoreAddress(const StoreInst *SI);
 };
 
 /// VariableHashCalculator - Calculate the global variable hash.
@@ -365,13 +355,13 @@ struct DigestCalculator<Function> {
 
 template <typename T>
 repodefinition::GOInfo
-calculateDigestAndDependenciesAndContributedToGVs(const T *GO) {
-  // Calculate the initial global object hash value, Dependencies and
-  // ContributedToGVs.
+calculateDigestAndDependenciesAndContributions(const T *GO) {
+  // Calculate the initial global object hash value, dependencies and
+  // contributions.
   typename DigestCalculator<T>::Calculator GOHC{GO};
   GOHC.calculateHash();
   return {std::move(GOHC.getHashResult()),
-          std::move(GOHC.hasher().getContributedToGVs()),
+          std::move(GOHC.hasher().getContributions()),
           std::move(GOHC.hasher().getDependencies())};
 }
 

--- a/llvm/test/Feature/Repo/Inputs/repo_contributions_dependencies_loop.ll
+++ b/llvm/test/Feature/Repo/Inputs/repo_contributions_dependencies_loop.ll
@@ -1,0 +1,24 @@
+target triple = "x86_64-pc-linux-gnu-repo"
+
+declare i32 @F();
+
+@Var1 = global i32 ()* @Func1, align 8
+@Var2 = global i32 ()* @F, align 8
+
+define i32 @Func1() {
+entry:
+  ret i32 2
+}
+
+define void @Main() {
+entry:
+  call void @Func2(i32()** @Var2)
+  ret void
+}
+
+define void @Func2(i32()** %P) {
+entry:
+  %0 = load i32() *, i32()** @Var1, align 8
+  store i32()* %0, i32() ** %P, align 8
+  ret void
+}

--- a/llvm/test/Feature/Repo/repo_GV_hash.ll
+++ b/llvm/test/Feature/Repo/repo_GV_hash.ll
@@ -11,7 +11,7 @@ target triple = "x86_64-pc-linux-gnu-repo"
 @fp_baz = global [1 x i32 (...)*] [i32 (...)* bitcast (i32 ()* @baz to i32 (...)*)], align 8
 
 ; CHECK: !3 = !RepoDefinition(name: "a", digest: [16 x i8] c"[[A:.+]]", linkage: internal, visibility: default, pruned: false)
-; CHECK: !4 = !RepoDefinition(name: "b", digest: [16 x i8] c"[[A]]", linkage: internal, visibility: default, pruned: false)
+; CHECK-NOT: !4 = !RepoDefinition(name: "b", digest: [16 x i8] c"[[A]]", linkage: internal, visibility: default, pruned: false)
 ; CHECK-NOT: !5 = !RepoDefinition(name: "c", digest: [16 x i8] c"[[A]]", linkage: internal, visibility: default, pruned: false)
 @a = internal global i32 1, align 4
 @b = internal global i32 1, align 4

--- a/llvm/test/Feature/Repo/repo_dependencies_noInline.ll
+++ b/llvm/test/Feature/Repo/repo_dependencies_noInline.ll
@@ -19,4 +19,4 @@ define void @g(i32* %P, i32 %V) noinline {
 }
 
 ;CHECK: GO Name:f
-;CHECK:    Dependencies: [ Z]
+;CHECK:  Contributions: [ Z]

--- a/llvm/test/Feature/Repo/repo_hash_contributions_func.ll
+++ b/llvm/test/Feature/Repo/repo_hash_contributions_func.ll
@@ -1,0 +1,48 @@
+; This test is used to check the hash calculation for the contributions.
+;
+; All GOs' information are shown below:
+;    | GO Name | Initial Dependencies | Contributions |
+;    |   Var1  |     [ Func1 ]        |      [ ]      |
+;    |   Var2  |       [ ]            |      [ ]      |
+;    |   Func1 |       [ ]            |      [ ]      |
+;    |   Main  |     [ Func2 ]        |     [ Var2 ]  |
+;    |   Func2 |       [ ]            |     [ Var1 ]  |
+;
+; This test checks that `Var2` digest is changed when `Func1` is modified.
+;
+; The test invokes five steps:
+;  1) Compile the initial code `Inputs/repo_contributions_dependencies_loop.ll` to %t.
+;  2) Compile `repo_hash_contributions.ll` to %t1.
+;  3) Dump the digest of `Var2` in %t.
+;  4) Dump the digest of `Var2` in %t1.
+;  5) Check the digests of `Var2` are different since the function `Func1` is changed.
+;
+; RUN: rm -rf %t.db
+; RUN: env REPOFILE=%t.db clang -c -O0 --target=x86_64-pc-linux-gnu-repo -x ir %S/Inputs/repo_contributions_dependencies_loop.ll -o %t
+; RUN: env REPOFILE=%t.db clang -c -O0 --target=x86_64-pc-linux-gnu-repo -x ir %s -o %t1
+; RUN: env REPOFILE=%t.db repo-fragments %t Var2 -repo=%t.db -digest-only > %t.d
+; RUN: env REPOFILE=%t.db repo-fragments %t1 Var2 -repo=%t.db -digest-only > %t1.d
+; RUN: not diff %t.d %t1.d
+
+declare i32 @F();
+
+@Var1 = global i32 ()* @Func1, align 8
+@Var2 = global i32 ()* @F, align 8
+
+define i32 @Func1() {
+entry:
+  ret i32 5
+}
+
+define void @Main() {
+entry:
+  call void @Func2(i32()** @Var2)
+  ret void
+}
+
+define void @Func2(i32()** %P) {
+entry:
+  %0 = load i32() *, i32()** @Var1, align 8
+  store i32()* %0, i32() ** %P, align 8
+  ret void
+}

--- a/llvm/test/Feature/Repo/repo_hash_contributions_var.ll
+++ b/llvm/test/Feature/Repo/repo_hash_contributions_var.ll
@@ -1,0 +1,48 @@
+; This test is used to check the hash calculation for the contributions.
+;
+; All GOs' information are shown below:
+;    | GO Name | Initial Dependencies | Contributions |
+;    |   Var1  |     [ Func1 ]        |      [ ]      |
+;    |   Var2  |       [ ]            |      [ ]      |
+;    |   Func1 |       [ ]            |      [ ]      |
+;    |   Main  |     [ Func2 ]        |     [ Var2 ]  |
+;    |   Func2 |       [ ]            |     [ Var1 ]  |
+;
+; This test checks that `Main` digest is changed when `Var2` is modified.
+;
+; The test invokes five steps:
+;  1) Compile the initial code `Inputs/repo_contributions_dependencies_loop.ll` to %t;
+;  2) Compile `repo_hash_contributions_var.ll` to %t1.
+;  3) Dump the digest of `Main` in %t.
+;  4) Dump the digest of `Main` in %t1.
+;  5) Check the digests of `Main` are different since the variable `Var2` is changed.
+;
+; RUN: rm -rf %t.db
+; RUN: env REPOFILE=%t.db clang -c -O0 --target=x86_64-pc-linux-gnu-repo -x ir %S/Inputs/repo_contributions_dependencies_loop.ll -o %t
+; RUN: env REPOFILE=%t.db clang -c -O0 --target=x86_64-pc-linux-gnu-repo -x ir %s -o %t1
+; RUN: env REPOFILE=%t.db repo-fragments %t Main -repo=%t.db -digest-only > %t.d
+; RUN: env REPOFILE=%t.db repo-fragments %t1 Main -repo=%t.db -digest-only > %t1.d
+; RUN: not diff %t.d %t1.d
+
+declare i32 @F();
+
+@Var1 = global i32 ()* @Func1, align 8
+@Var2 = global i32 ()* @F, align 16
+
+define i32 @Func1() {
+entry:
+  ret i32 2
+}
+
+define void @Main() {
+entry:
+  call void @Func2(i32()** @Var2)
+  ret void
+}
+
+define void @Func2(i32()** %P) {
+entry:
+  %0 = load i32() *, i32()** @Var1, align 8
+  store i32()* %0, i32() ** %P, align 8
+  ret void
+}

--- a/llvm/test/Feature/Repo/repo_hash_graph_contributions.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_contributions.ll
@@ -1,0 +1,36 @@
+; Test that we correctly generate contributions from load and store instructions.
+; global variable B has a reference to global variable A which will be a Contribution for B.
+; function setB has a reference to global variable B which will be a Contributions for setB.
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest %s -o /dev/null 2>&1 | FileCheck %s
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@A = global i32 1, align 4
+@B = global i32* @A, align 8
+
+define void @setB() {
+entry:
+    %0 = load i32*, i32** @B, align 8
+    store i32 3, i32* %0, align 4
+    ret void
+}
+
+;CHECK: GO Name:A
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ ]
+;CHECK: GO Name:B
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ A]
+;CHECK: GO Name:setB
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ B]
+;CHECK: GO Name:setB
+;CHECK:     Final Dependencies: [ B]
+;CHECK: GO Name:A
+;CHECK:     Final Dependencies: [ B]
+;CHECK: GO Name:B
+;CHECK:     Final Dependencies: [ A,setB]

--- a/llvm/test/Feature/Repo/repo_hash_graph_contributions_1.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_contributions_1.ll
@@ -1,0 +1,38 @@
+; Test that we correctly generate contributions from load and call instructions.
+; global variable Str has a reference to global variable .str which will be a Contributions for Str.
+; function sayHello has a reference to global variable Str which will be a Contributions for sayHello.
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest %s -o /dev/null 2>&1 | FileCheck %s
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@Str = internal global i8* getelementptr inbounds ([14 x i8], [14 x i8]* @.str, i32 0, i32 0), align 8
+@.str = private unnamed_addr constant [14 x i8] c"Hello, World\0A\00", align 1
+
+define void @sayHello() {
+entry:
+  %0 = load i8*, i8** @Str, align 8
+  %call = call i32 (i8*, ...) @printf(i8* %0)
+  ret void
+}
+
+declare i32 @printf(i8*, ...)
+
+;CHECK: GO Name:Str
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ .str]
+;CHECK: GO Name:.str
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ ]
+;CHECK: GO Name:sayHello
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ Str]
+;CHECK: GO Name:sayHello
+;CHECK:     Final Dependencies: [ Str]
+;CHECK: GO Name:Str
+;CHECK:     Final Dependencies: [ .str,sayHello]
+;CHECK: GO Name:.str
+;CHECK:     Final Dependencies: [ Str]

--- a/llvm/test/Feature/Repo/repo_hash_graph_contributions_2.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_contributions_2.ll
@@ -1,0 +1,27 @@
+; Test that we correctly generate contributions from store instruction.
+; function main has a reference to global variable Var which will be a Contributions for main.
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest %s -o /dev/null 2>&1 | FileCheck %s
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@Var = global i32 1, align 4
+define i32 @main() {
+entry:
+  store i32 2, i32* @Var, align 4
+  ret i32 2
+}
+
+;CHECK: GO Name:Var
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ ]
+;CHECK: GO Name:main
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ Var]
+;CHECK: GO Name:main
+;CHECK:     Final Dependencies: [ Var]
+;CHECK: GO Name:Var
+;CHECK:     Final Dependencies: [ main]

--- a/llvm/test/Feature/Repo/repo_hash_graph_dependencies.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_dependencies.ll
@@ -1,0 +1,27 @@
+; Test that we correctly generate dependencies from a global variable whose initial value directly referenced to a function.
+; global variable FPtr has a reference to function add which will be a Dependencies for FPtr.
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest %s -o /dev/null 2>&1 | FileCheck %s
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@FPtr = global i32 (i32, i32)* @add, align 8
+define i32 @add(i32 %a, i32 %b)  {
+entry:
+    %add = add nsw i32 %a, %b
+    ret i32 %add
+}
+
+;CHECK: GO Name:FPtr
+;CHECK:     Initial Dependencies: [ add]
+;CHECK:     Contributions: [ ]
+;CHECK: GO Name:add
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ ]
+;CHECK: GO Name:add
+;CHECK:     Final Dependencies: [ ]
+;CHECK: GO Name:FPtr
+;CHECK:     Final Dependencies: [ add]

--- a/llvm/test/Feature/Repo/repo_hash_graph_dependencies_1.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_dependencies_1.ll
@@ -1,0 +1,26 @@
+; Test that we correctly generate dependencies from a global variable whose initial value indirectly referenced to a function through the bitcast instruction.
+; global variable A has a reference to function func which will be a Dependencies for A.
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest %s -o /dev/null 2>&1 | FileCheck %s
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@A = local_unnamed_addr global i8* bitcast (i32 ()* @func to i8*), align 8
+define i32 @func() #0 {
+entry:
+  ret i32 2
+}
+
+;CHECK: GO Name:A
+;CHECK:     Initial Dependencies: [ func]
+;CHECK:     Contributions: [ ]
+;CHECK: GO Name:func
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ ]
+;CHECK: GO Name:func
+;CHECK:     Final Dependencies: [ ]
+;CHECK: GO Name:A
+;CHECK:     Final Dependencies: [ func]

--- a/llvm/test/Feature/Repo/repo_hash_graph_dependencies_2.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_dependencies_2.ll
@@ -1,0 +1,31 @@
+; Test that we correctly generate dependencies from function.
+; function g has a reference to function f which will be a Dependencies for g.
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest %s -o /dev/null 2>&1 | FileCheck %s
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+define i32 @f() {
+entry:
+    ret i32 2
+}
+define i32 @g() {
+entry:
+    %call = call i32 @f()
+    %add = add nsw i32 %call, 1
+    ret i32 %add
+}
+
+;CHECK: GO Name:f
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ ]
+;CHECK: GO Name:g
+;CHECK:     Initial Dependencies: [ f]
+;CHECK:     Contributions: [ ]
+;CHECK: GO Name:f
+;CHECK:     Final Dependencies: [ ]
+;CHECK: GO Name:g
+;CHECK:     Final Dependencies: [ f]

--- a/llvm/test/Feature/Repo/repo_hash_graph_mixed.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_mixed.ll
@@ -1,0 +1,40 @@
+; Test GO's information of Dependencies and Contributions.
+;
+; RUN: rm -f %t.db
+; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
+
+; REQUIRES: asserts
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+@G = internal global i32 0, align 4
+define void @setTo(i32* %P, i32 %V) {
+entry:
+    %0 = load i32, i32* %P, align 4
+    %add = add nsw i32 %0, %V
+    store i32 %add, i32* %P, align 4
+    ret void
+}
+define i32 @test() {
+entry:
+    call void @setTo(i32* @G, i32 2)
+    %0 = load i32, i32* @G, align 4
+    ret i32 %0
+}
+
+
+;CHECK: GO Name:G
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ ]
+;CHECK: GO Name:setTo
+;CHECK:     Initial Dependencies: [ ]
+;CHECK:     Contributions: [ ]
+;CHECK: GO Name:test
+;CHECK:     Initial Dependencies: [ setTo]
+;CHECK:     Contributions: [ G]
+;CHECK: GO Name:setTo
+;CHECK:     Final Dependencies: [ ]
+;CHECK: GO Name:test
+;CHECK:     Final Dependencies: [ setTo,G]
+;CHECK: GO Name:G
+;CHECK:     Final Dependencies: [ test]

--- a/llvm/test/Feature/Repo/repo_pruning_dependents_3.ll
+++ b/llvm/test/Feature/Repo/repo_pruning_dependents_3.ll
@@ -41,7 +41,6 @@
 target triple = "x86_64-pc-linux-gnu-elf"
 
 @str = private constant [6 x i8] c"Ipsum\00", align 1
-@src = global i8* getelementptr inbounds ([6 x i8], [6 x i8]* @str, i32 0, i32 0), align 4
 
 define void @a() {
 entry:

--- a/llvm/unittests/IR/RepoDefinitionTest.cpp
+++ b/llvm/unittests/IR/RepoDefinitionTest.cpp
@@ -100,12 +100,8 @@ TEST_F(SingleModule, NoCalleeSame) {
   EXPECT_EQ(FooInfo.InitialDigest, BarInfo.InitialDigest)
       << "Expected that functions of foo and bar have the same initial hash "
          "value";
-  EXPECT_TRUE(FooInfo.Contributions.empty())
-      << "Expected that the foo's contribution list is empty.";
   EXPECT_TRUE(FooInfo.Dependencies.empty())
       << "Expected that the foo's dependencies list is empty.";
-  EXPECT_TRUE(BarInfo.Contributions.empty())
-      << "Expected that the bar's contributions list is empty.";
   EXPECT_TRUE(BarInfo.Dependencies.empty())
       << "Expected that the bar's dependencies list is empty.";
   // Check the GOs' final digest.
@@ -171,12 +167,8 @@ TEST_F(SingleModule, OneCalleeSameNameSameBody) {
   EXPECT_EQ(FooInfo.InitialDigest, BarInfo.InitialDigest)
       << "Expected that functions of foo and bar have the same initial hash "
          "value";
-  EXPECT_TRUE(FooInfo.Contributions.empty())
-      << "Expected that the foo's contributions list is empty.";
   EXPECT_THAT(FooInfo.Dependencies, ::testing::UnorderedElementsAre(G))
       << "Expected foo's Dependencies list is { G }";
-  EXPECT_TRUE(BarInfo.Contributions.empty())
-      << "Expected that the bar's contributions list is empty.";
   EXPECT_THAT(BarInfo.Dependencies, ::testing::UnorderedElementsAre(G))
       << "Expected bar's Dependencies list is { G }";
   // Check the GOs' final digest.
@@ -225,12 +217,8 @@ TEST_F(SingleModule, OneCalleeDiffNameSameBody) {
   EXPECT_NE(FooInfo.InitialDigest, BarInfo.InitialDigest)
       << "Expected that functions of foo and bar have the different initial "
          "hash value";
-  EXPECT_TRUE(FooInfo.Contributions.empty())
-      << "Expected that the foo's contributions list is empty.";
   EXPECT_THAT(FooInfo.Dependencies, ::testing::UnorderedElementsAre(G))
       << "Expected foo's Dependencies list is { G }";
-  EXPECT_TRUE(BarInfo.Contributions.empty())
-      << "Expected that the bar's contributions list is empty.";
   EXPECT_THAT(BarInfo.Dependencies, ::testing::UnorderedElementsAre(P))
       << "Expected bar's Dependencies list is { P }";
   // Check the GOs' final digest.
@@ -373,12 +361,8 @@ TEST_F(SingleModule, CallEachOther) {
   EXPECT_NE(FooInfo.InitialDigest, BarInfo.InitialDigest)
       << "Expected that functions of foo and bar have the different initial "
          "hash value";
-  EXPECT_TRUE(FooInfo.Contributions.empty())
-      << "Expected that the foo's contributions list is empty.";
   EXPECT_THAT(FooInfo.Dependencies, ::testing::ElementsAre(Bar))
       << "Expected foo's Dependencies list is {bar}";
-  EXPECT_TRUE(BarInfo.Contributions.empty())
-      << "Expected that the bar's contributions list is empty.";
   EXPECT_THAT(BarInfo.Dependencies, ::testing::ElementsAre(Foo))
       << "Expected bar's Dependencies list is {foo}";
   // Check the GOs' final digest.
@@ -430,16 +414,10 @@ TEST_F(SingleModule, OneCalleeLoop) {
   EXPECT_EQ(FooInfo.InitialDigest, BarInfo.InitialDigest)
       << "Expected that functions of foo and bar have the same initial hash "
          "value";
-  EXPECT_TRUE(FooInfo.Contributions.empty())
-      << "Expected that the foo's contributions list is empty.";
   EXPECT_THAT(FooInfo.Dependencies, ::testing::ElementsAre(P))
       << "Expected foo's Dependencies list is {P}";
-  EXPECT_TRUE(BarInfo.Contributions.empty())
-      << "Expected that the bar's contributions list is empty.";
   EXPECT_THAT(BarInfo.Dependencies, ::testing::ElementsAre(P))
       << "Expected bar's Dependencies list is {P}";
-  EXPECT_TRUE(PInfo.Contributions.empty())
-      << "Expected that the p's contributions list is empty.";
   EXPECT_THAT(PInfo.Dependencies, ::testing::ElementsAre(Bar))
       << "Expected p's Dependencies list is {bar}";
   // Check the GOs' final digest.
@@ -519,24 +497,14 @@ TEST_F(SingleModule, TwolevelsCall) {
       << "Expected that functions of foo and bar have the same initial "
          "hash value";
 
-  EXPECT_TRUE(ZInfo.Contributions.empty())
-      << "Expected that the z's Contributions list is empty.";
   EXPECT_TRUE(ZInfo.Dependencies.empty())
       << "Expected that the z's Dependencies list is empty.";
-  EXPECT_TRUE(QInfo.Contributions.empty())
-      << "Expected that the q's Contributions list is empty.";
   EXPECT_TRUE(QInfo.Dependencies.empty())
       << "Expected that the q's Dependencies list is empty.";
-  EXPECT_TRUE(PInfo.Contributions.empty())
-      << "Expected that the p's Contributions list is empty.";
   EXPECT_THAT(PInfo.Dependencies, ::testing::ElementsAre(Z))
       << "Expected that the p's Dependencies list is {Z}";
-  EXPECT_TRUE(FooInfo.Contributions.empty())
-      << "Expected that the foo's Contributions list is empty.";
   EXPECT_THAT(FooInfo.Dependencies, ::testing::UnorderedElementsAre(P, Q))
       << "Expected that the foo's Dependencies list is {P, Q}";
-  EXPECT_TRUE(BarInfo.Contributions.empty())
-      << "Expected that the bar's Contributions list is empty.";
   EXPECT_THAT(BarInfo.Dependencies, ::testing::UnorderedElementsAre(P, Q))
       << "Expected that the bar's Dependencies list is {P, Q}";
   EXPECT_TRUE(repodefinition::generateRepoDefinitions(*M))
@@ -583,16 +551,10 @@ TEST_F(SingleModule, SingleContribution) {
   const Function *Setto = M->getFunction("setto");
   const repodefinition::GOInfo &SettoInfo = InfoMap[Setto];
 
-  EXPECT_THAT(ZInfo.Contributions, ::testing::UnorderedElementsAre(Test))
-      << "Expected that the Z's Contributions list is {Test}";
-  EXPECT_TRUE(ZInfo.Dependencies.empty())
-      << "Expected that Z's Dependencies list is empty";
-  EXPECT_TRUE(TestInfo.Contributions.empty())
-      << "Expected that the test's Contributions list is empty.";
+  EXPECT_THAT(ZInfo.Dependencies, ::testing::UnorderedElementsAre(Test))
+      << "Expected that the Z's Dependencies list is {Test}";
   EXPECT_THAT(TestInfo.Dependencies, ::testing::UnorderedElementsAre(Z, Setto))
       << "Expected that the test's Dependencies list is {Z, setto}";
-  EXPECT_TRUE(SettoInfo.Contributions.empty())
-      << "Expected that the setto's Contributions list is empty.";
   EXPECT_TRUE(SettoInfo.Dependencies.empty())
       << "Expected that the setto's Dependencies list is empty.";
 }
@@ -644,11 +606,9 @@ TEST_F(SingleModule, MultipleContribution) {
   const Function *Test1 = M->getFunction("test1");
   const Function *Test2 = M->getFunction("test2");
 
-  EXPECT_THAT(ZInfo.Contributions,
+  EXPECT_THAT(ZInfo.Dependencies,
               ::testing::UnorderedElementsAre(Test, Test1, Test2))
-      << "Expected that the Z's Contributions list is {Test, Test1, Test2}";
-  EXPECT_TRUE(ZInfo.Dependencies.empty())
-      << "Expected that Z's Dependencies list is empty";
+      << "Expected that the Z's Dependencies list is {Test, Test1, Test2}";
 }
 
 // The definition metadate fixture for double modules.


### PR DESCRIPTION
The problem is caused by the incorrect hash calculation. When we calculate the initial digest for each global object (GO), we also collect the GO's contributions and dependencies. These represent the different directions during the hash calculation. A detailed explanation is given on [this wiki page](https://github.com/SNSystems/llvm-project-prepo/wiki/The-RepoMetadataGeneration-and-RepoPruning-Passes).

The case that shows the problem is:

~~~C
int V1 = 1;
int V2 = 0;
int func() {
  V2 = V2 + V1;
  return V2;
}
~~~

After the initial hash calculation, the following information is collected:

Name | Contributions | Dependencies
---- | ------------- | ------------
V1 | [ ] | [ ]
V2 | [ ] | [ ]
func | [ V2 ] | [ V1 ]

The current hash algorithm only accumulates the func() hash to the V2 hash, which is not enough. If V1 initial value changes, the V2 value will change. Therefore, the V1 hash needs to be accumulated to the V2 hash. The correct informations for func() should be:

Name | Contributions | Dependencies
---- | ------------- | ------------
func | [ V1, V2 ] | [ ]

By converting contributions to dependencies, it will fix the issue because the hash algorithm will only consider the GO’s dependencies, which are in the same direction when calculating the GO’s hash.

The commit includes the following changes:
1) Rename ‘ContributedToGVs’ as ‘Contributions’ and make sure there is no intersection between the GO’s Contribution and its Dependencies.
2) Convert contributions to dependencies to get a single direction graph, which is used by the hash calculation.

Fix for <https://github.com/SNSystems/llvm-project-prepo/issues/110>.