### PR TITLE
Remove the "prepo-digest" macro definition to fix the warning.

### DIFF
--- a/llvm/lib/IR/RepoDefinition.cpp
+++ b/llvm/lib/IR/RepoDefinition.cpp
@@ -26,8 +26,6 @@
 
 using namespace llvm;
 
-#define DEBUG_TYPE "prepo-digest"
-
 STATISTIC(NumFunctions, "Number of functions hashed");
 STATISTIC(NumVariables, "Number of variables hashed");
 STATISTIC(NumMemoizedHashes, "Number of memoized hashes");

--- a/llvm/test/Feature/Repo/repo_dependencies_noInline.ll
+++ b/llvm/test/Feature/Repo/repo_dependencies_noInline.ll
@@ -1,7 +1,7 @@
 ; Check that @Z is @f's only dependency. @g is not included because it is a noinline function.
 ;
 ; RUN: rm -f %t.db
-; RUN: env REPOFILE=%t.db opt -S -O3 -debug-only prepo-digest -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: env REPOFILE=%t.db opt -S -O3 -debug-only ir -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 

--- a/llvm/test/Feature/Repo/repo_hash_graph_contributions.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_contributions.ll
@@ -3,7 +3,7 @@
 ; function setB has a reference to global variable B which will be a Contributions for setB.
 ;
 ; RUN: rm -f %t.db
-; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: env REPOFILE=%t.db opt -S -debug-only ir %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 

--- a/llvm/test/Feature/Repo/repo_hash_graph_contributions_1.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_contributions_1.ll
@@ -3,7 +3,7 @@
 ; function sayHello has a reference to global variable Str which will be a Contributions for sayHello.
 ;
 ; RUN: rm -f %t.db
-; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: env REPOFILE=%t.db opt -S -debug-only ir %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 

--- a/llvm/test/Feature/Repo/repo_hash_graph_contributions_2.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_contributions_2.ll
@@ -2,7 +2,7 @@
 ; function main has a reference to global variable Var which will be a Contributions for main.
 ;
 ; RUN: rm -f %t.db
-; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: env REPOFILE=%t.db opt -S -debug-only ir %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 

--- a/llvm/test/Feature/Repo/repo_hash_graph_dependencies.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_dependencies.ll
@@ -2,7 +2,7 @@
 ; global variable FPtr has a reference to function add which will be a Dependencies for FPtr.
 ;
 ; RUN: rm -f %t.db
-; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: env REPOFILE=%t.db opt -S -debug-only ir %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 

--- a/llvm/test/Feature/Repo/repo_hash_graph_dependencies_1.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_dependencies_1.ll
@@ -2,7 +2,7 @@
 ; global variable A has a reference to function func which will be a Dependencies for A.
 ;
 ; RUN: rm -f %t.db
-; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: env REPOFILE=%t.db opt -S -debug-only ir %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 

--- a/llvm/test/Feature/Repo/repo_hash_graph_dependencies_2.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_dependencies_2.ll
@@ -2,7 +2,7 @@
 ; function g has a reference to function f which will be a Dependencies for g.
 ;
 ; RUN: rm -f %t.db
-; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: env REPOFILE=%t.db opt -S -debug-only ir %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 

--- a/llvm/test/Feature/Repo/repo_hash_graph_mixed.ll
+++ b/llvm/test/Feature/Repo/repo_hash_graph_mixed.ll
@@ -1,7 +1,7 @@
 ; Test GO's information of Dependencies and Contributions.
 ;
 ; RUN: rm -f %t.db
-; RUN: env REPOFILE=%t.db opt -S -debug-only prepo-digest -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: env REPOFILE=%t.db opt -S -debug-only ir -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 

--- a/llvm/test/Feature/Repo/repo_hash_hybrid.ll
+++ b/llvm/test/Feature/Repo/repo_hash_hybrid.ll
@@ -7,7 +7,7 @@
 ; }
 ;
 ; RUN: rm -f %t.db
-; RUN: env REPOFILE=%t.db opt -S -stats -debug-only prepo -debug-only prepo-digest -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: env REPOFILE=%t.db opt -S -stats -debug-only prepo -debug-only ir -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 
@@ -79,7 +79,7 @@ entry:
 ;CHECK: Returning pre-computed hash for "D"
 ;CHECK: Recording result for "A"
 ;
-;CHECK:      6 prepo-digest - Number of functions hashed
-;CHECK-NEXT: 4 prepo-digest - Number of memoized hashes
-;CHECK-NEXT: 7 prepo-digest - Visited times of memoized hashes
-;CHECK-NEXT: 6 prepo-digest - Visited times of unmemoized hashes
+;CHECK:      6 ir - Number of functions hashed
+;CHECK-NEXT: 4 ir - Number of memoized hashes
+;CHECK-NEXT: 7 ir - Visited times of memoized hashes
+;CHECK-NEXT: 6 ir - Visited times of unmemoized hashes

--- a/llvm/test/Feature/Repo/repo_hash_loop.ll
+++ b/llvm/test/Feature/Repo/repo_hash_loop.ll
@@ -5,7 +5,7 @@
 ; }
 ;
 ; RUN: rm -f %t.db
-; RUN: env REPOFILE=%t.db opt -S -stats -debug-only prepo -debug-only prepo-digest -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: env REPOFILE=%t.db opt -S -stats -debug-only prepo -debug-only ir -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 
@@ -48,7 +48,7 @@ entry:
 ;CHECK: Hashing back reference to #1
 ;CHECK: Recording result for "C"
 ;
-;CHECK:      3 prepo-digest - Number of functions hashed
-;CHECK-NEXT: 1 prepo-digest - Number of memoized hashes
-;CHECK-NEXT: 1 prepo-digest - Visited times of memoized hashes
-;CHECK-NEXT: 6 prepo-digest - Visited times of unmemoized hashes
+;CHECK:      3 ir - Number of functions hashed
+;CHECK-NEXT: 1 ir - Number of memoized hashes
+;CHECK-NEXT: 1 ir - Visited times of memoized hashes
+;CHECK-NEXT: 6 ir - Visited times of unmemoized hashes

--- a/llvm/test/Feature/Repo/repo_hash_self_loop.ll
+++ b/llvm/test/Feature/Repo/repo_hash_self_loop.ll
@@ -5,7 +5,7 @@
 ; }
 ;
 ; RUN: rm -f %t.db
-; RUN: env REPOFILE=%t.db opt -S -stats -debug-only prepo -debug-only prepo-digest -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: env REPOFILE=%t.db opt -S -stats -debug-only prepo -debug-only ir -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 
@@ -34,6 +34,6 @@ entry:
 ;CHECK: Returning pre-computed hash for "B"
 ;CHECK: Recording result for "A"
 ;
-;CHECK:      2 prepo-digest - Number of functions hashed
-;CHECK-NEXT: 2 prepo-digest - Number of memoized hashes
-;CHECK-NEXT: 3 prepo-digest - Visited times of memoized hashes
+;CHECK:      2 ir - Number of functions hashed
+;CHECK-NEXT: 2 ir - Number of memoized hashes
+;CHECK-NEXT: 3 ir - Visited times of memoized hashes

--- a/llvm/test/Feature/Repo/repo_hash_simple_case.ll
+++ b/llvm/test/Feature/Repo/repo_hash_simple_case.ll
@@ -6,7 +6,7 @@
 ; }
 ;
 ; RUN: rm -f %t.db
-; RUN: env REPOFILE=%t.db opt -S -stats -debug-only prepo -debug-only prepo-digest -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: env REPOFILE=%t.db opt -S -stats -debug-only prepo -debug-only ir -mtriple x86_64-pc-linux-gnu-repo %s -o /dev/null 2>&1 | FileCheck %s
 
 ; REQUIRES: asserts
 
@@ -41,6 +41,6 @@ entry:
 ;CHECK: Returning pre-computed hash for "B"
 ;CHECK: Recording result for "C"
 ;
-;CHECK:      3 prepo-digest - Number of functions hashed
-;CHECK-NEXT: 3 prepo-digest - Number of memoized hashes
-;CHECK-NEXT: 5 prepo-digest - Visited times of memoized hashes
+;CHECK:      3 ir - Number of functions hashed
+;CHECK-NEXT: 3 ir - Number of memoized hashes
+;CHECK-NEXT: 5 ir - Visited times of memoized hashes


### PR DESCRIPTION
When building the llvm-project-prepo, the following warning is given.

    llvm-project-prepo/llvm/lib/IR/RepoDefinition.cpp:29: warning: "DEBUG_TYPE" redefined
        #define DEBUG_TYPE "prepo-digest"
	
    In file included from llvm-project-prepo/llvm/lib/IR/LLVMContextImpl.h:18,
                    from /home/maggie/github/llvm-project-prepo/llvm/lib/IR/RepoDefinition.cpp:15:
    llvm-project-prepo/llvm/lib/IR/ConstantsContext.h:40: note: this is the location of the previous definition
    #define DEBUG_TYPE "ir"

Removed the "prepo-digest" macro definition to fix the warning.