### PR TITLE
Switch to the new LLVM (Apache 2.0-based) license.

### DIFF
--- a/llvm/include/llvm/IR/RepoDefinition.h
+++ b/llvm/include/llvm/IR/RepoDefinition.h
@@ -1,11 +1,10 @@
 //===- RepoDefinition.h - Program repository definition metadata structure-===//
 //
-//                     The LLVM Compiler Infrastructure
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
-//
-//===---------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_IR_REPODEFINITION_H
 #define LLVM_IR_REPODEFINITION_H

--- a/llvm/include/llvm/IR/RepoGlobals.h
+++ b/llvm/include/llvm/IR/RepoGlobals.h
@@ -1,9 +1,8 @@
-//===----  RepoGlobals.h - Program repository globals  -------------------===//
+//===-  RepoGlobals.h - Program repository globals  -----------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/include/llvm/IR/RepoHashCalculator.h
+++ b/llvm/include/llvm/IR/RepoHashCalculator.h
@@ -1,9 +1,8 @@
 //===- RepoHashCalculator.h - Implement Hash Calculation --------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/llvm/include/llvm/MC/MCAsmInfoRepo.h
+++ b/llvm/include/llvm/MC/MCAsmInfoRepo.h
@@ -1,9 +1,8 @@
-//===-- llvm/MC/MCAsmInfoRepo.h - Repo Asm info -----------------*- C++ -*-===//
+//===- llvm/MC/MCAsmInfoRepo.h - Repo Asm info ------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/include/llvm/MC/MCRepoObjectWriter.h
+++ b/llvm/include/llvm/MC/MCRepoObjectWriter.h
@@ -1,9 +1,8 @@
-//===-- llvm/MC/MCRepoObjectWriter.h - Repository Writer --------*- C++ -*-===//
+//===- llvm/MC/MCRepoObjectWriter.h - Repository Writer ---------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/include/llvm/MC/MCRepoStreamer.h
+++ b/llvm/include/llvm/MC/MCRepoStreamer.h
@@ -1,9 +1,8 @@
 //===- MCRepoStreamer.h - MCStreamer Repo Object File Interface -*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/include/llvm/MC/MCRepoTicketFile.h
+++ b/llvm/include/llvm/MC/MCRepoTicketFile.h
@@ -1,9 +1,8 @@
 //===- MCRepoTicketFile.h - Repo Ticket File --------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/include/llvm/MC/MCSectionRepo.h
+++ b/llvm/include/llvm/MC/MCSectionRepo.h
@@ -1,9 +1,8 @@
 //===- MCSectionRepo.h - Repository Machine Code Sections -------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/llvm/include/llvm/MC/MCSymbolRepo.h
+++ b/llvm/include/llvm/MC/MCSymbolRepo.h
@@ -1,11 +1,10 @@
-//===- MCSymbolRepo.h -  ---------------------------------------*- C++ -*-===//
+//===- MCSymbolRepo.h -  ----------------------------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
-//
-//===---------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #ifndef LLVM_MC_MCSYMBOLREPO_H
 #define LLVM_MC_MCSYMBOLREPO_H
 

--- a/llvm/lib/IR/RepoDefinition.cpp
+++ b/llvm/lib/IR/RepoDefinition.cpp
@@ -1,9 +1,8 @@
 //===- RepoDefinition.cpp - Implement Repo definition metadata. -*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/llvm/lib/IR/RepoGlobals.cpp
+++ b/llvm/lib/IR/RepoGlobals.cpp
@@ -1,9 +1,8 @@
-//===----  RepoGlobals.cpp - Program repository globals  ------------------===//
+//===-  RepoGlobals.cpp - Program repository globals  ---------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/lib/IR/RepoHashCalculator.cpp
+++ b/llvm/lib/IR/RepoHashCalculator.cpp
@@ -1,9 +1,8 @@
 //===- RepoHashCalculator.cpp - Implement Hash Calculation ----------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/llvm/lib/MC/MCAsmInfoRepo.cpp
+++ b/llvm/lib/MC/MCAsmInfoRepo.cpp
@@ -1,9 +1,8 @@
-//===-- MCAsmInfoRepo.cpp - Repo asm properties -----------------*- C++ -*-===//
+//===- MCAsmInfoRepo.cpp - Repo asm properties ------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/llvm/lib/MC/MCRepoObjectTargetWriter.cpp
+++ b/llvm/lib/MC/MCRepoObjectTargetWriter.cpp
@@ -1,9 +1,8 @@
-//===-- MCRepoObjectTargetWriter.cpp - Repository Target Writer Subclass---===//
+//===- MCRepoObjectTargetWriter.cpp - Repository Target Writer Subclass ---===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/lib/MC/MCRepoStreamer.cpp
+++ b/llvm/lib/MC/MCRepoStreamer.cpp
@@ -1,11 +1,10 @@
 //===- lib/MC/MCRepoStreamer.cpp - Repo Object Output ------------------- -===//
 //
-//                     The LLVM Compiler Infrastructure
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
-//
-//===--------------------------------------------------------------- ------===//
+//===----------------------------------------------------------------------===//
 //
 // This file assembles .s files and emits ELF .o object files.
 //

--- a/llvm/lib/MC/MCRepoTicketFile.cpp
+++ b/llvm/lib/MC/MCRepoTicketFile.cpp
@@ -1,9 +1,8 @@
 //===- MCRepoTicketFile.cpp - Repo Ticket File ------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/lib/MC/MCSectionRepo.cpp
+++ b/llvm/lib/MC/MCSectionRepo.cpp
@@ -1,9 +1,8 @@
 //===- MCSectionRepo.cpp - Repo Code Section Representation -----*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/llvm/lib/MC/RepoObjectWriter.cpp
+++ b/llvm/lib/MC/RepoObjectWriter.cpp
@@ -1,9 +1,8 @@
 //===- lib/MC/RepoObjectWriter.cpp - Program Repository Writer-------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/llvm/lib/Target/X86/MCTargetDesc/X86RepoObjectWriter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86RepoObjectWriter.cpp
@@ -1,11 +1,10 @@
-//===-- X86RepoObjectWriter.cpp - X86 Program Repository Writer ----------===//
+//===- X86RepoObjectWriter.cpp - X86 Program Repository Writer ------------===//
 //
-//                     The LLVM Compiler Infrastructure
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
-//
-//===---------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "MCTargetDesc/X86FixupKinds.h"
 #include "MCTargetDesc/X86MCTargetDesc.h"

--- a/llvm/lib/Transforms/IPO/RepoMetadataGeneration.cpp
+++ b/llvm/lib/Transforms/IPO/RepoMetadataGeneration.cpp
@@ -1,9 +1,8 @@
-//===----    RepoMetadataGeneration.cpp - Create a program repository -----===//
+//===- RepoMetadataGeneration.cpp - Create a program repository -----------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/lib/Transforms/IPO/RepoPruning.cpp
+++ b/llvm/lib/Transforms/IPO/RepoPruning.cpp
@@ -1,9 +1,8 @@
-//===----  RepoPruning.cpp - Program repository pruning  ----===//
+//===- RepoPruning.cpp - Program repository pruning -----------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/tools/repo-create-ticket/RepoCreateTicket.cpp
+++ b/llvm/tools/repo-create-ticket/RepoCreateTicket.cpp
@@ -1,9 +1,8 @@
-//===- repo-create-ticket - Create a ticket file from a repository. -------===//
+//===- RepoCreateTicket.cpp - Create a ticket file from a repository. -----===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/tools/repo-fragments/RepoFragments.cpp
+++ b/llvm/tools/repo-fragments/RepoFragments.cpp
@@ -1,9 +1,8 @@
-//===- repo-fragments - Dump the names and digests using a ticket file. --===//
+//===- RepoFragments.cpp - Dump the names and digests using a ticket file.-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/tools/repo-ticket-dump/RepoTicketDump.cpp
+++ b/llvm/tools/repo-ticket-dump/RepoTicketDump.cpp
@@ -1,9 +1,8 @@
-//===- repo-ticket-dump - Dump the contents of a prepo ticket file. -------===//
+//===- RepoTicketDump.cpp - Dump the contents of a prepo ticket file. -----===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/tools/repo2obj/R2OELFOutputSection.cpp
+++ b/llvm/tools/repo2obj/R2OELFOutputSection.cpp
@@ -1,9 +1,8 @@
-//===-- R2OELFOutputSection.cpp -------------------------------------------===//
+//===- R2OELFOutputSection.cpp --------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/tools/repo2obj/R2OELFOutputSection.h
+++ b/llvm/tools/repo2obj/R2OELFOutputSection.h
@@ -1,9 +1,8 @@
-//===-- R2OELFOutputSection.h ---------------------------------------------===//
+//===- R2OELFOutputSection.h ----------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 #ifndef LLVM_TOOLS_REPO2OBJ_ELFOUTPUTSECTION_H

--- a/llvm/tools/repo2obj/R2OELFSectionType.cpp
+++ b/llvm/tools/repo2obj/R2OELFSectionType.cpp
@@ -1,9 +1,8 @@
-//===-- R2OELFSectionType.cpp ---------------------------------------------===//
+//===- R2OELFSectionType.cpp ----------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 #include "R2OELFSectionType.h"

--- a/llvm/tools/repo2obj/R2OELFSectionType.h
+++ b/llvm/tools/repo2obj/R2OELFSectionType.h
@@ -1,9 +1,8 @@
-//===-- R2OELFSectionType.h -----------------------------------------------===//
+//===- R2OELFSectionType.h ------------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 #ifndef LLVM_TOOLS_REPO2OBJ_ELFSECTIONTYPE_H

--- a/llvm/tools/repo2obj/R2OELFStringTable.cpp
+++ b/llvm/tools/repo2obj/R2OELFStringTable.cpp
@@ -1,9 +1,8 @@
-//===-- R2OELFStringTable.cpp ---------------------------------------------===//
+//===- R2OELFStringTable.cpp ----------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/tools/repo2obj/R2OELFStringTable.h
+++ b/llvm/tools/repo2obj/R2OELFStringTable.h
@@ -1,9 +1,8 @@
-//===-- R2OELFStringTable.h -----------------------------------------------===//
+//===- R2OELFStringTable.h ------------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/tools/repo2obj/R2OELFSymbolTable.h
+++ b/llvm/tools/repo2obj/R2OELFSymbolTable.h
@@ -1,9 +1,8 @@
-//===-- R2OELFSymbolTable.h -----------------------------------------------===//
+//===- R2OELFSymbolTable.h ------------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/tools/repo2obj/WriteHelpers.cpp
+++ b/llvm/tools/repo2obj/WriteHelpers.cpp
@@ -1,9 +1,8 @@
-//===-- WriteHelpers.cpp --------------------------------------------------===//
+//===- WriteHelpers.cpp ---------------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/tools/repo2obj/WriteHelpers.h
+++ b/llvm/tools/repo2obj/WriteHelpers.h
@@ -1,9 +1,8 @@
-//===-- WriteHelpers.h ----------------------------------------------------===//
+//===- WriteHelpers.h -----------------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/tools/repo2obj/repo2obj.cpp
+++ b/llvm/tools/repo2obj/repo2obj.cpp
@@ -1,9 +1,8 @@
-//===- repo2obj - Convert a Repository ticket to an ELF object file ------===//
+//===- repo2obj.cpp - Convert a Repository ticket to an ELF object file ---===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/unittests/IR/RepoDefinitionTest.cpp
+++ b/llvm/unittests/IR/RepoDefinitionTest.cpp
@@ -1,9 +1,8 @@
-//===-llvm/unittest/IR/RepoDefinitionTest.cpp - Definition Metadata tests-===//
+//===- llvm/unittest/IR/RepoDefinitionTest.cpp - Definition Metadata tests-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/unittests/IR/RepoModuleHashTest.cpp
+++ b/llvm/unittests/IR/RepoModuleHashTest.cpp
@@ -1,9 +1,8 @@
-//===- llvm/unittest/IR/RepoModuleHashTest.cpp - PassManager tests --------===//
+//===- llvm/unittest/IR/RepoModuleHashTest.cpp - Module hash tests --------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/unittests/Transforms/Utils/RepoHashCalculator.cpp
+++ b/llvm/unittests/Transforms/Utils/RepoHashCalculator.cpp
@@ -1,9 +1,8 @@
 //===- RepoHashCalculator.cpp - Unit tests for RepoHashCalculator ---------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/utils/repo/archive.py
+++ b/llvm/utils/repo/archive.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
+# ===- archive.py - ------------------------------------------*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===-----------------------------------------------------------------------===#
 
 from __future__ import print_function
 

--- a/llvm/utils/repo/docker/build.sh
+++ b/llvm/utils/repo/docker/build.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+#
+#===- llvm/utils/repo/docker/build.sh -------------------------------------===//
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===-----------------------------------------------------------------------===//
 ./build_docker_image.sh \
     --branch master \
     --docker-tag latest \

--- a/llvm/utils/repo/elf.cmake
+++ b/llvm/utils/repo/elf.cmake
@@ -1,46 +1,11 @@
-#*       _  __  *
-#*   ___| |/ _| *
-#*  / _ \ | |_  *
-#* |  __/ |  _| *
-#*  \___|_|_|   *
-#*              *
-#===- elf.cmake -----------------------------------------------------------===//
-# Copyright (c) 2017-2019 by Sony Interactive Entertainment, Inc.
-# All rights reserved.
-#
-# Developed by:
-#   Toolchain Team
-#   SN Systems, Ltd.
-#   www.snsystems.com
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the
-# "Software"), to deal with the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
-#
-# - Redistributions of source code must retain the above copyright notice,
-#   this list of conditions and the following disclaimers.
-#
-# - Redistributions in binary form must reproduce the above copyright
-#   notice, this list of conditions and the following disclaimers in the
-#   documentation and/or other materials provided with the distribution.
-#
-# - Neither the names of SN Systems Ltd., Sony Interactive Entertainment,
-#   Inc. nor the names of its contributors may be used to endorse or
-#   promote products derived from this Software without specific prior
-#   written permission.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-# IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR
-# ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-# SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
-#===----------------------------------------------------------------------===//
+/*===- elf.cmake ----------------------------------------------------------===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
 
 set (triple "x86_64-pc-linux-gnu")
 

--- a/llvm/utils/repo/link.py
+++ b/llvm/utils/repo/link.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
+# ===- link.py - ---------------------------------------------*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===-----------------------------------------------------------------------===#
 
 import logging
 import subprocess

--- a/llvm/utils/repo/repo.cmake
+++ b/llvm/utils/repo/repo.cmake
@@ -1,46 +1,11 @@
-#*                        *
-#*  _ __ ___ _ __   ___   *
-#* | '__/ _ \ '_ \ / _ \  *
-#* | | |  __/ |_) | (_) | *
-#* |_|  \___| .__/ \___/  *
-#*          |_|           *
-#===- repo.cmake ----------------------------------------------------------===//
-# Copyright (c) 2017-2018 by Sony Interactive Entertainment, Inc.
-# All rights reserved.
-#
-# Developed by:
-#   Toolchain Team
-#   SN Systems, Ltd.
-#   www.snsystems.com
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the
-# "Software"), to deal with the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
-#
-# - Redistributions of source code must retain the above copyright notice,
-#   this list of conditions and the following disclaimers.
-#
-# - Redistributions in binary form must reproduce the above copyright
-#   notice, this list of conditions and the following disclaimers in the
-#   documentation and/or other materials provided with the distribution.
-#
-# - Neither the names of SN Systems Ltd., Sony Interactive Entertainment,
-#   Inc. nor the names of its contributors may be used to endorse or
-#   promote products derived from this Software without specific prior
-#   written permission.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-# IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR
-# ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-# SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
-#===----------------------------------------------------------------------===//
+/*===- repo.cmake ---------------------------------------------------------===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
 
 #this one not so much
 SET (CMAKE_SYSTEM_VERSION 1)

--- a/llvm/utils/repo/test-scripts/pstore_test.py
+++ b/llvm/utils/repo/test-scripts/pstore_test.py
@@ -1,48 +1,13 @@
 #!/usr/bin/env python
-# *            _                   _            _    *
-# *  _ __  ___| |_ ___  _ __ ___  | |_ ___  ___| |_  *
-# * | '_ \/ __| __/ _ \| '__/ _ \ | __/ _ \/ __| __| *
-# * | |_) \__ \ || (_) | | |  __/ | ||  __/\__ \ |_  *
-# * | .__/|___/\__\___/|_|  \___|  \__\___||___/\__| *
-# * |_|                                              *
-# ===- pstore_test.py ------------------------------------------------------===//
-# Copyright (c) 2017-2018 by Sony Interactive Entertainment, Inc.
-# All rights reserved.
 #
-# Developed by:
-#   Toolchain Team
-#   SN Systems, Ltd.
-#   www.snsystems.com
+# ===- pstore_test.py - --------------------------------------*- python -*--===#
 #
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the
-# "Software"), to deal with the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# - Redistributions of source code must retain the above copyright notice,
-#   this list of conditions and the following disclaimers.
-#
-# - Redistributions in binary form must reproduce the above copyright
-#   notice, this list of conditions and the following disclaimers in the
-#   documentation and/or other materials provided with the distribution.
-#
-# - Neither the names of SN Systems Ltd., Sony Interactive Entertainment,
-#   Inc. nor the names of its contributors may be used to endorse or
-#   promote products derived from this Software without specific prior
-#   written permission.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-# IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR
-# ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-# SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
-# ===----------------------------------------------------------------------===//
-''' A utility which automatically tests the built llvm-prepo toolchain
+# ===-----------------------------------------------------------------------===#
+''' A utility which automatically tests the built llvm-project-prepo toolchain
     using the pstore unit and system tests. '''
 import argparse
 import collections

--- a/llvm/utils/repo/wrap_tool.py
+++ b/llvm/utils/repo/wrap_tool.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
+# ===- wrap_tool.py - ----------------------------------------*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===-----------------------------------------------------------------------===#
 """
 Enables the use of tools which don't yet understand the Program Repository with
 repository ticket files.


### PR DESCRIPTION
Updated the private repo related files in the llvm-project-prepo tree to the new license. Please note  that the rld project will be updated by using the pstore boilerplate utility and not included here. 