### PR TITLE
Reliably record ticket file directories for repository GC

### DIFF
--- a/llvm/include/llvm/MC/MCRepoTicketFile.h
+++ b/llvm/include/llvm/MC/MCRepoTicketFile.h
@@ -15,6 +15,8 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorOr.h"
 
+#include "pstore/core/index_types.hpp"
+#include "pstore/core/transaction.hpp"
 #include "pstore/core/uuid.hpp"
 #include "pstore/support/uint128.hpp"
 
@@ -110,6 +112,13 @@ ErrorOr<pstore::uuid> getOwnerIDFromTicket(const llvm::MemoryBufferRef &Buffer);
 /// \param TicketPath  The path of a ticket file.
 /// \returns  The ID of the owning database or an error.
 ErrorOr<pstore::uuid> getOwnerIDFromTicket(StringRef TicketPath);
+
+Expected<llvm::SmallString<256>> realTicketDirectory(const StringRef &Path);
+
+void recordTicketDirectory(
+    pstore::transaction<pstore::transaction_lock> &Transaction,
+    std::shared_ptr<pstore::index::path_index> const &Paths,
+    llvm::StringRef const &OutputPath);
 
 } // end namespace repo
 } // end namespace mc

--- a/llvm/test/tools/repo-create-ticket/ticket-path.ll
+++ b/llvm/test/tools/repo-create-ticket/ticket-path.ll
@@ -1,0 +1,17 @@
+; REQUIRES: asserts
+; RUN: rm -rf %t && mkdir -p %t
+; RUN: env REPOFILE=%t/db.db llc -filetype=obj %s -o %t/t1.o
+; RUN: repo-ticket-dump %t/t1.o > %t/out1.txt
+; RUN: echo 'CHECK: ticket directory:%t' > %t/expected.txt
+; RUN: cat %t/out1.txt | repo-create-ticket -debug -debug-only repo-create-ticket -repo=%t/db.db -o %t/t2.o - 2>&1 | FileCheck %t/expected.txt
+
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+define void @f() !repo_definition !0 {
+entry:
+  ret void
+}
+
+!repo.definitions = !{!0}
+!0 = !RepoDefinition(name: "f", digest: [16 x i8] c"\DC\8BWeQ\E4\03\E6\F3:\DE\D1\9F\90\AC\F7", linkage: external, visibility: default, pruned: false)

--- a/llvm/test/tools/repo2obj/extern_mixed_weak_global_references.json
+++ b/llvm/test/tools/repo2obj/extern_mixed_weak_global_references.json
@@ -21,11 +21,10 @@
     {
       // generation 1
       "names":[
-        "x86_64-pc-linux-gnu-repo",
-        "/path",
-        "a",
-        "_ZTW1a",
-        "_ZTH1a"
+        "x86_64-pc-linux-gnu-repo", // 0
+        "a",      // 1
+        "_ZTW1a", // 2
+        "_ZTH1a"  // 3
       ],
       "fragments":{
         "38ba192db4955408af33b70221a5c1b2":{
@@ -33,19 +32,18 @@
               "align":16,
               "data":"ULgAAAAASIXAdAXoAAAAAGRIiwQlAAAAAEgDBQAAAABZww==",
               "xfixups":[
-                {"name":4,"type":10,"is_weak":false,"offset":2,"addend":0}, //"_ZTH1a"
-                {"name":4,"type":4,"is_weak":true,"offset":12,"addend":-4}, //"_ZTH1a"
-                {"name":2,"type":22,"offset":28,"addend":-4} //"a"
+                {"name":3,"type":10,"is_weak":false,"offset":2,"addend":0}, //"_ZTH1a"
+                {"name":3,"type":4,"is_weak":true,"offset":12,"addend":-4}, //"_ZTH1a"
+                {"name":1,"type":22,"offset":28,"addend":-4} //"a"
               ]
             }
           }
       },
       "compilations":{
         "e865ac76298a3007c24cad11885532d4":{
-          "path":1, //"/path"
           "triple":0, //"x86_64-pc-linux-gnu-repo"
           "definitions":[
-            {"digest":"38ba192db4955408af33b70221a5c1b2","name":3,"linkage":"link_once_odr","visibility":"hidden"} //"_ZTW1a"
+            {"digest":"38ba192db4955408af33b70221a5c1b2","name":2,"linkage":"link_once_odr","visibility":"hidden"} //"_ZTW1a"
           ]
         }
       }

--- a/llvm/test/tools/repo2obj/extern_weak_references.json
+++ b/llvm/test/tools/repo2obj/extern_weak_references.json
@@ -21,11 +21,10 @@
     {
       // generation 1
       "names":[
-        "x86_64-pc-linux-gnu-repo",
-        "/path",
-        "a",
-        "_ZTW1a",
-        "_ZTH1a"
+        "x86_64-pc-linux-gnu-repo", // 0
+        "a", // 1
+        "_ZTW1a", // 2
+        "_ZTH1a" // 3
       ],
       "fragments":{
         "38ba192db4955408af33b70221a5c1b2":{
@@ -33,19 +32,18 @@
               "align":16,
               "data":"ULgAAAAASIXAdAXoAAAAAGRIiwQlAAAAAEgDBQAAAABZww==",
               "xfixups":[
-                {"name":4,"type":10,"is_weak":true,"offset":2,"addend":0}, //"_ZTH1a"
-                {"name":4,"type":4,"is_weak":true,"offset":12,"addend":-4}, //"_ZTH1a"
-                {"name":2,"type":22,"offset":28,"addend":-4} //"a"
+                {"name":3,"type":10,"is_weak":true,"offset":2,"addend":0}, //"_ZTH1a"
+                {"name":3,"type":4,"is_weak":true,"offset":12,"addend":-4}, //"_ZTH1a"
+                {"name":1,"type":22,"offset":28,"addend":-4} //"a"
               ]
             }
           }
       },
       "compilations":{
         "e865ac76298a3007c24cad11885532d4":{
-          "path":1, //"/path"
           "triple":0, //"x86_64-pc-linux-gnu-repo"
           "definitions":[
-            {"digest":"38ba192db4955408af33b70221a5c1b2","name":3,"linkage":"link_once_odr","visibility":"hidden"} //"_ZTW1a"
+            {"digest":"38ba192db4955408af33b70221a5c1b2","name":2,"linkage":"link_once_odr","visibility":"hidden"} //"_ZTW1a"
           ]
         }
       }

--- a/llvm/tools/repo-create-ticket/CMakeLists.txt
+++ b/llvm/tools/repo-create-ticket/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(LLVM_LINK_COMPONENTS
     Object
+    MC
     Support
 )
 add_llvm_tool (repo-create-ticket

--- a/rld/include/rld/context.h
+++ b/rld/include/rld/context.h
@@ -110,6 +110,8 @@ public:
   pstore::database &Db;
   mutable std::mutex IOMut;
 
+  std::atomic<uint64_t> ELFStringTableSize;
+
   pstore::repo::compilation const &recordCompilation(
       pstore::extent<pstore::repo::compilation> const &CompilationExtent);
 

--- a/rld/include/rld/context.h
+++ b/rld/include/rld/context.h
@@ -45,6 +45,9 @@ std::string loadStdString(pstore::database const &Db,
 
 llvm::StringRef stringViewAsRef(pstore::raw_sstring_view S);
 
+size_t stringLength(pstore::database const &Db,
+                    pstore::typed_address<pstore::indirect_string> Addr);
+
 class Symbol;
 
 #ifndef NDEBUG

--- a/rld/lib/ElfOutput.cpp
+++ b/rld/lib/ElfOutput.cpp
@@ -92,12 +92,11 @@ buildSectionNameStringTable(Layout *const Lout) {
 // ~~~~~~~~~~~~~~~~~~~~
 uint64_t prepareStringTable(rld::Context &Ctxt, rld::Layout *const Lout,
                             const GlobalSymbolsContainer &Globals) {
-  const uint64_t StringTableSize = std::accumulate(
-      std::begin(Globals), std::end(Globals), uint64_t{1},
-      [&Ctxt](const uint64_t Acc, const Symbol &Sym) {
-        pstore::shared_sstring_view Owner;
-        return Acc + loadString(Ctxt.Db, Sym.name(), &Owner).length() + 1U;
-      });
+  const uint64_t StringTableSize =
+      std::accumulate(std::begin(Globals), std::end(Globals), uint64_t{1},
+                      [&Ctxt](const uint64_t Acc, const Symbol &Sym) {
+                        return Acc + stringLength(Ctxt.Db, Sym.name()) + 1U;
+                      });
 
   OutputSection &StrTab = Lout->Sections[SectionKind::strtab];
   StrTab.AlwaysEmit = true;

--- a/rld/lib/ElfOutput.cpp
+++ b/rld/lib/ElfOutput.cpp
@@ -92,18 +92,18 @@ buildSectionNameStringTable(Layout *const Lout) {
 // ~~~~~~~~~~~~~~~~~~~~
 uint64_t prepareStringTable(rld::Context &Ctxt, rld::Layout *const Lout,
                             const GlobalSymbolsContainer &Globals) {
-  const uint64_t StringTableSize =
-      std::accumulate(std::begin(Globals), std::end(Globals), uint64_t{1},
-                      [&Ctxt](const uint64_t Acc, const Symbol &Sym) {
-                        return Acc + stringLength(Ctxt.Db, Sym.name()) + 1U;
-                      });
+  const auto StringTableSize = Ctxt.ELFStringTableSize.load();
+  assert(StringTableSize ==
+         std::accumulate(std::begin(Globals), std::end(Globals), uint64_t{1},
+                         [&Ctxt](const uint64_t Acc, const Symbol &Sym) {
+                           return Acc + stringLength(Ctxt.Db, Sym.name()) + 1U;
+                         }));
 
   OutputSection &StrTab = Lout->Sections[SectionKind::strtab];
   StrTab.AlwaysEmit = true;
   StrTab.FileSize = StringTableSize;
   StrTab.MaxAlign = 1U;
   StrTab.Writer = nullptr;
-
   return StringTableSize;
 }
 

--- a/rld/lib/context.cpp
+++ b/rld/lib/context.cpp
@@ -33,6 +33,14 @@ rld::loadString(pstore::database const &Db,
       .as_string_view(Owner);
 }
 
+size_t rld::stringLength(pstore::database const &Db,
+                         pstore::typed_address<pstore::indirect_string> Addr) {
+  using namespace pstore::serialize;
+  return read<pstore::indirect_string>(
+             archive::database_reader{Db, Addr.to_address()})
+      .length();
+}
+
 std::string
 rld::loadStdString(pstore::database const &Db,
                    pstore::typed_address<pstore::indirect_string> Addr) {

--- a/rld/lib/context.cpp
+++ b/rld/lib/context.cpp
@@ -60,7 +60,7 @@ llvm::StringRef rld::stringViewAsRef(pstore::raw_sstring_view S) {
 // ctor
 // ~~~~
 rld::Context::Context(pstore::database &D, llvm::StringRef EntryPoint)
-    : Db{D}, EntryPoint_{EntryPoint},
+    : Db{D}, ELFStringTableSize{1U}, EntryPoint_{EntryPoint},
       ShadowDb_{createShadowMemory(static_cast<std::size_t>(Db.size()))} {}
 
 void rld::Context::MmapDeleter::operator()(std::uint8_t *P) const {

--- a/rld/lib/symbol.cpp
+++ b/rld/lib/symbol.cpp
@@ -500,6 +500,8 @@ NotNull<Symbol *> SymbolResolver::addReference(
 Symbol *SymbolResolver::add(NotNull<GlobalSymbolsContainer *> const Globals,
                             pstore::repo::definition const &Def,
                             uint32_t InputOrdinal) {
+  Context_.ELFStringTableSize += stringLength(Context_.Db, Def.name) + 1U;
+
   return &Globals->emplace_back(
       Def.name,
       Symbol::Body(&Def, pstore::repo::fragment::load(Context_.Db, Def.fext),
@@ -587,6 +589,7 @@ referenceSymbol(Context &Ctxt, LocalSymbolsContainer const &Locals,
       symbolShadow(Ctxt, Name),
       [&]() {
         // Called for a reference to a (thus far) undefined symbol.
+        Ctxt.ELFStringTableSize += stringLength(Ctxt.Db, Name);
         return SymbolResolver::addUndefined(Globals, Undefs, Name, Strength);
       },
       [&](Symbol *const Sym) {

--- a/rld/test/phdr.json
+++ b/rld/test/phdr.json
@@ -32,14 +32,13 @@
         {
             // generation 1
             "names":[
-                "x86_64-pc-linux-gnu-repo",
-                "main",
-                "printf",
-                ".str.1",
-                ".str",
-                "ultimate_answer",
-                "/path",
-                "foo"
+                "x86_64-pc-linux-gnu-repo", // 0
+                "main", // 1
+                "printf", // 2
+                ".str.1", // 3
+                ".str", // 4
+                "ultimate_answer", // 5
+                "foo" // 6
             ],
             "fragments":{
                 "f9bb578a7abfc702dc7fa54f7b4af05f":{
@@ -86,7 +85,6 @@
             },
             "compilations":{
                 "008fecf0ccab0c7a71a5672579eaca1e":{
-                    "path":6, //"/path"
                     "triple":0, //"x86_64-pc-linux-gnu-repo"
                     "definitions":[
                         {"digest":"f9bb578a7abfc702dc7fa54f7b4af05f","name":5,"linkage":"external"}, //"ultimate_answer"
@@ -96,10 +94,9 @@
                     ]
                 },
                 "6c951506a8c75884774cd5d4507740cd":{
-                    "path":6, //"/path"
                     "triple":0, //"x86_64-pc-linux-gnu-repo"
                     "definitions":[
-                        {"digest":"024badfa2effcb85e10be56851688097","name":7,"linkage":"external"} //"foo"
+                        {"digest":"024badfa2effcb85e10be56851688097","name":6,"linkage":"external"} //"foo"
                     ]
                 }
             }

--- a/rld/test/reused_fragment.json
+++ b/rld/test/reused_fragment.json
@@ -17,12 +17,11 @@
   "transactions": [
     {
       "names": [
-        "/path", // 0
-        "x86_64-pc-linux-gnu-repo", // 1
-        "f", // 2
-        "g", // 3
-        "h", // 4
-        "j"  // 5
+        "x86_64-pc-linux-gnu-repo", // 0
+        "f", // 1
+        "g", // 2
+        "h", // 3
+        "j"  // 4
       ],
 
       "fragments": {
@@ -36,7 +35,7 @@
           "read_only": {
             "data" : "ZGF0YQ==",
             "xfixups": [
-              { "name": 4, "type": 0, "offset": 0, "addend": 0 } // "h"
+              { "name": 3, "type": 0, "offset": 0, "addend": 0 } // "h"
             ]
           }
         }
@@ -45,21 +44,19 @@
       "compilations": {
         // This compilation has two definitions that reference the same fragment (8cda).
         "072e60601c5545ca9e6d759ab9d7484f": {
-          "path"  : 0, // "/path"
-          "triple": 1, // "x86_64-pc-linux-gnu-repo"
+          "triple": 0, // "x86_64-pc-linux-gnu-repo"
           "definitions": [
-            { "digest": "8cda64e4d658472f885f58d331025fbd", "name": 2, "linkage": "external" }, // "f"
-            { "digest": "8cda64e4d658472f885f58d331025fbd", "name": 3, "linkage": "external" }, // "g"
-            { "digest": "75dc28989269433bb972a59f17403dab", "name": 4, "linkage": "external" }  // "h"
+            { "digest": "8cda64e4d658472f885f58d331025fbd", "name": 1, "linkage": "external" }, // "f"
+            { "digest": "8cda64e4d658472f885f58d331025fbd", "name": 2, "linkage": "external" }, // "g"
+            { "digest": "75dc28989269433bb972a59f17403dab", "name": 3, "linkage": "external" }  // "h"
           ]
         },
 
         // A compilation which contains a third reference to that fragment (8cda).
         "cdbabbba384d4f12a6c6656eada97d72": {
-          "path"  : 0, // "/path"
-          "triple": 1, // "x86_64-pc-linux-gnu-repo"
+          "triple": 0, // "x86_64-pc-linux-gnu-repo"
           "definitions": [
-            { "digest": "8cda64e4d658472f885f58d331025fbd", "name": 5, "linkage": "external" } // "j"
+            { "digest": "8cda64e4d658472f885f58d331025fbd", "name": 4, "linkage": "external" } // "j"
           ]
         }
       } // compilations

--- a/rld/test/rodata_segment.json
+++ b/rld/test/rodata_segment.json
@@ -24,7 +24,7 @@
   "id":"43777a3d-88d0-40ec-928f-f7abbfdbacdb",
   "transactions":[
     {
-      "names":[ "/path", "x86_64-pc-linux-gnu-repo", "a", "b" ],
+      "names":[ "x86_64-pc-linux-gnu-repo", "a", "b" ],
 
       "fragments":{
         // Used by ta.o
@@ -37,19 +37,17 @@
       "compilations":{
         // Will be ta.o
         "b24bcc617ea04e1ebb049c7d9474b207":{
-          "path":0,   //"/path"
-          "triple":1, //"x86_64-pc-linux-gnu-repo"
+          "triple":0, //"x86_64-pc-linux-gnu-repo"
           "definitions":[
-            {"digest":"55d19e2f6f02436a930780ab3ca1149e","name":2,"linkage":"external"} //"a"
+            {"digest":"55d19e2f6f02436a930780ab3ca1149e","name":1,"linkage":"external"} //"a"
           ]
         },
 
         // Will be tb.o
         "179954423c360b6469069364ba86e7af":{
-          "path":0,   //"/path"
-          "triple":1, //"x86_64-pc-linux-gnu-repo"
+          "triple":0, //"x86_64-pc-linux-gnu-repo"
           "definitions":[
-            {"digest":"833d8e4e88bf4f39b5ea6766ce29bdfb","name":3,"linkage":"external"}  //"b"
+            {"digest":"833d8e4e88bf4f39b5ea6766ce29bdfb","name":2,"linkage":"external"}  //"b"
           ]
         }
       } // compilatons

--- a/rld/test/shdr.json
+++ b/rld/test/shdr.json
@@ -27,14 +27,13 @@
         {
             // generation 1
             "names":[
-                "x86_64-pc-linux-gnu-repo",
-                "main",
-                "printf",
-                ".str.1",
-                ".str",
-                "ultimate_answer",
-                "/path",
-                "foo"
+                "x86_64-pc-linux-gnu-repo", // 0
+                "main", // 1
+                "printf", // 2
+                ".str.1", // 3
+                ".str", // 4
+                "ultimate_answer", // 5
+                "foo" // 6
             ],
             "fragments":{
                 "f9bb578a7abfc702dc7fa54f7b4af05f":{
@@ -62,7 +61,6 @@
             },
             "compilations":{
                 "008fecf0ccab0c7a71a5672579eaca1e":{
-                    "path":6, //"/path"
                     "triple":0, //"x86_64-pc-linux-gnu-repo"
                     "definitions":[
                         {"digest":"f9bb578a7abfc702dc7fa54f7b4af05f","name":5,"linkage":"external"}, //"ultimate_answer"
@@ -98,10 +96,9 @@
             },
             "compilations":{
                 "6c951506a8c75884774cd5d4507740cd":{
-                    "path":6, //"/path"
                     "triple":0, //"x86_64-pc-linux-gnu-repo"
                     "definitions":[
-                        {"digest":"024badfa2effcb85e10be56851688097","name":7,"linkage":"external"} //"foo"
+                        {"digest":"024badfa2effcb85e10be56851688097","name":6,"linkage":"external"} //"foo"
                     ]
                 }
             }

--- a/rld/test/undefined_reference.json
+++ b/rld/test/undefined_reference.json
@@ -10,9 +10,8 @@
         {
             "names":[
                 "x86_64-pc-linux-gnu-repo", //0
-                "/path",                    //1
-                "f",                        //2
-                "g"                         //3
+                "f",                        //1
+                "g"                         //2
             ],
             "fragments":{
                 "9e30555726ae19d10a4dc6f1097a8def":{
@@ -20,17 +19,16 @@
                         "align":16,
                         "data":"VUiJ5bgrAAAAXcM=",
                         "xfixups": [
-                            {"name":3,"type":4,"is_weak":false,"offset":5,"addend":-4} //"g"
+                            {"name":2,"type":4,"is_weak":false,"offset":5,"addend":-4} //"g"
                         ]
                     }
                 }
             },
             "compilations":{
                 "25f1ea3ef1413aa52b0ef9567647acd1":{
-                    "path":1, //"/path"
                     "triple":0, //"x86_64-pc-linux-gnu-repo"
                     "definitions":[
-                        {"digest":"9e30555726ae19d10a4dc6f1097a8def","name":2,"linkage":"external"} //"f"
+                        {"digest":"9e30555726ae19d10a4dc6f1097a8def","name":1,"linkage":"external"} //"f"
                     ]
                 }
             }

--- a/rld/test/undefined_weak_reference.json
+++ b/rld/test/undefined_weak_reference.json
@@ -10,9 +10,8 @@
         {
             "names":[
                 "x86_64-pc-linux-gnu-repo", //0
-                "/path",                    //1
-                "f",                        //2
-                "g"                         //3
+                "f",                        //1
+                "g"                         //2
             ],
             "fragments":{
                 "9e30555726ae19d10a4dc6f1097a8def":{
@@ -20,17 +19,16 @@
                         "align":16,
                         "data":"VUiJ5bgrAAAAXcM=",
                         "xfixups": [
-                            {"name":3,"type":4,"is_weak":true,"offset":5,"addend":-4} //"g"
+                            {"name":2,"type":4,"is_weak":true,"offset":5,"addend":-4} //"g"
                         ]
                     }
                 }
             },
             "compilations":{
                 "25f1ea3ef1413aa52b0ef9567647acd1":{
-                    "path":1, //"/path"
                     "triple":0, //"x86_64-pc-linux-gnu-repo"
                     "definitions":[
-                        {"digest":"9e30555726ae19d10a4dc6f1097a8def","name":2,"linkage":"external"} //"f"
+                        {"digest":"9e30555726ae19d10a4dc6f1097a8def","name":1,"linkage":"external"} //"f"
                     ]
                 }
             }

--- a/rld/unit_tests/rld/CompilationBuilder.h
+++ b/rld/unit_tests/rld/CompilationBuilder.h
@@ -123,14 +123,12 @@ CompilationBuilder::compile(NameAndLinkageIterator First,
                           NameAdder_.add(Transaction, NL.first), NL.second};
       });
 
-  constexpr auto Path = "/path";
   constexpr auto Triple = "machine-vendor-os";
   auto const Result = CompilationIndex->insert(
       Transaction,
       std::make_pair(
           Digest{CompilationIndex->size()},
-          Compilation::alloc(Transaction, NameAdder_.add(Transaction, Path),
-                             NameAdder_.add(Transaction, Triple),
+          Compilation::alloc(Transaction, NameAdder_.add(Transaction, Triple),
                              std::begin(Definitions), std::end(Definitions))));
   NameAdder_.flush(Transaction); // Write the bodies of the strings.
   Transaction.commit();


### PR DESCRIPTION
Part of a fix for issue #133 along with pstore [PR#88](https://github.com/SNSystems/pstore/pull/88). 


I have been very aware every time a new test for rld is committed using the pstore exchange format, that these JSON files will need to be revisited following the fix for issue #133 since this will change the underlying schema. That has been a disincentive to add new tests and added to the need to resolve this problem properly.

The matching pstore change adds a new index to the repo which contains the set of ticket file paths. Here we update the compiler and repo-create-ticket to manipulate this new collection.

Note that CI for this PR will fail until pstore PR#88 is committed.