### PR TITLE
Fix separators produced when when explicit name(s) were requested.

### DIFF
--- a/llvm/test/tools/repo-fragments/tool-options-test.ll
+++ b/llvm/test/tools/repo-fragments/tool-options-test.ll
@@ -12,6 +12,7 @@
 ; RUN: repo-fragments -repo=%t.db -d %t.o | FileCheck --check-prefix=DIGESTONLY %s
 ; RUN: repo-fragments -repo=%t.db -comma %t.o | FileCheck --check-prefix=COMMA %s
 ; RUN: repo-fragments -repo=%t.db -c %t.o | FileCheck --check-prefix=COMMA %s
+; RUN: repo-fragments -repo=%t.db %t.o f | FileCheck --check-prefix=NAME --match-full-lines --strict-whitespace %s
 ;
 ; BASIC: f: {{([[:xdigit:]]{32})}}
 ; BASIC: v: {{([[:xdigit:]]{32})}}
@@ -20,6 +21,7 @@
 ; DIGESTONLY: {{([[:xdigit:]]{32})}}
 ; CHECK2: {{([[:xdigit:]]{32})}}
 ; COMMA: f: {{([[:xdigit:]]{32})}},v: {{([[:xdigit:]]{32})}}
+; NAME:f: {{([[:xdigit:]]{32})}}
 ;
 target triple = "x86_64-pc-linux-gnu-repo"
 

--- a/llvm/test/tools/repo-fragments/tool-options-test.ll
+++ b/llvm/test/tools/repo-fragments/tool-options-test.ll
@@ -12,7 +12,7 @@
 ; RUN: repo-fragments -repo=%t.db -d %t.o | FileCheck --check-prefix=DIGESTONLY %s
 ; RUN: repo-fragments -repo=%t.db -comma %t.o | FileCheck --check-prefix=COMMA %s
 ; RUN: repo-fragments -repo=%t.db -c %t.o | FileCheck --check-prefix=COMMA %s
-; RUN: repo-fragments -repo=%t.db %t.o f | FileCheck --check-prefix=NAME --match-full-lines --strict-whitespace %s
+; RUN: repo-fragments -repo=%t.db -c %t.o f | FileCheck --check-prefix=NAME --match-full-lines --strict-whitespace %s
 ;
 ; BASIC: f: {{([[:xdigit:]]{32})}}
 ; BASIC: v: {{([[:xdigit:]]{32})}}

--- a/llvm/tools/repo-fragments/RepoFragments.cpp
+++ b/llvm/tools/repo-fragments/RepoFragments.cpp
@@ -74,11 +74,11 @@ static constexpr unsigned clamp_to_unsigned(size_t S) {
 namespace {
 
 cl::opt<std::string> TicketPath(cl::Positional,
-                                cl::desc("<Path of the ticket file>"),
+                                cl::desc("<ticket file>"),
                                 cl::Required);
 cl::list<std::string> Names(cl::Positional, cl::ZeroOrMore,
-                            cl::desc("<Definitions(s) to be displayed>"));
-cl::opt<std::string> RepoPath("repo", cl::Optional,
+                            cl::desc("[<name>...]"));
+cl::opt<std::string> RepoPath("repo",
                               cl::desc("Path of the program repository"),
                               cl::init("./clang.db"));
 cl::opt<bool> DigestOnly("digest-only", cl::init(false),
@@ -152,9 +152,8 @@ int main(int argc, char *argv[]) {
     // Dump this digest (and perhaps name) if it was requested by the user.
     if (IsRequestedName(MemberNameRef)) {
       outs() << Sep << makeNameAndDigest(DigestOnly, MemberNameRef, CM.digest);
+      Sep = UseComma ? "," : "\n";
     }
-
-    Sep = UseComma ? "," : "\n";
   }
   outs() << '\n';
   return EXIT_SUCCESS;


### PR DESCRIPTION
If one of more explicit definition names were listed on the
command-line, the tool could incorrectly emit a leading ,/cr
character. If passing the output to pstore-dump --fragments, this
would result in an error because the digest list was badly formed.

Here’s are concrete examples of the failure:
~~~
$ repo-fragments switch.o main_

main_: 1fdffa3225f4c7ca1eb5aade961b45d1
$ repo-fragments switch.o main_
,1fdffa3225f4c7ca1eb5aade961b45d1
$ repo-fragments -d -c switch.o main_
,1fdffa3225f4c7ca1eb5aade961b45d1
$ pstore-dump --fragment=$(repo-fragments -d -c switch.o main_) clang.db 
pstore-dump: Unknown value ',1fdffa3225f4c7ca1eb5aade961b45d1'
~~~
The first output has unwanted leading whitespace; the second an unwanted leading comma; the third is an error from pstore-dump caused by the unwanted leading comma.

Lit tested added to explicitly check for whitespace in the default output.

Altered the command-line usage to better explain the use of the tool.