### PR TITLE
Modify repo.cmake to support musl libc.a and LLVM libc++.a.

### DIFF
--- a/libcxxabi/src/CMakeLists.txt
+++ b/libcxxabi/src/CMakeLists.txt
@@ -16,8 +16,13 @@ set(LIBCXXABI_SOURCES
   # Internal files
   abort_message.cpp
   fallback_malloc.cpp
-  private_typeinfo.cpp
 )
+
+# private_typeinfo.cpp needs to be built with RTTI enabled.
+# Don't include private_typeinfo.cpp in the source since repo doesn't yet support rtti.
+if (NOT ${CMAKE_CXX_COMPILER_TARGET} MATCHES "x86_64-pc-linux-gnu-repo")
+  list(APPEND LIBCXXABI_SOURCES private_typeinfo.cpp)
+endif()
 
 if (LIBCXXABI_ENABLE_NEW_DELETE_DEFINITIONS)
   list(APPEND LIBCXXABI_SOURCES stdlib_new_delete.cpp)

--- a/llvm/utils/repo/Makefile
+++ b/llvm/utils/repo/Makefile
@@ -1,0 +1,123 @@
+#
+# Makefile for building LLVM runtime libraries using musl-prepo libc (requires GNU make).
+# LLVM runtime libraries include the unwind library, compiler-rt, c++ ABI library
+# and libc++ library.
+# prerequisite: 1) installed the musl-prepo libc library in the $(MUSL) directory.
+#               2) built llvm-project-prepo in the $(LLVM_BUILD) directory. 
+#
+
+# The path of the directory in which llvm-project-prepo sources is checked out from git.
+LLVM_REPO = ${HOME}/github/llvm-project-prepo
+TOOLCHAIN_FILE=$(LLVM_REPO)/llvm/utils/repo/repo.cmake
+# The path of the llvm-project-prepo build directory.
+LLVM_BUILD = ${LLVM_REPO}/build
+# The path of the directory in which llvm libraries are installed.
+LLVM = ${HOME}/LLVM
+# The path of the directory in which musl libc is installed.
+MUSL = ${HOME}/musl
+
+libunwind.a:
+	if [ -d "$(LLVM_REPO)/build_libunwind" ];then                         \
+		rm -rf $(LLVM_REPO)/build_libunwind;                          \
+	fi
+	cd $(LLVM_REPO)  &&                                                   \
+	mkdir build_libunwind && cd build_libunwind  &&                       \
+	cmake -D musl=Yes                                                     \
+		-D CMAKE_BUILD_TYPE=Release                                   \
+		-D LLVM_PATH=../                                              \
+		-D LIBUNWIND_ENABLE_SHARED=No                                 \
+		-D LIBUNWIND_ENABLE_STATIC=Yes                                \
+		-D CMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)                     \
+		-D CMAKE_INSTALL_PREFIX=$(LLVM)                               \
+		../libunwind &&                                               \
+	make -j 8 &&                                                          \
+	make install
+
+libcompiler-rt.a:
+	if [ -d "$(LLVM_REPO)/build_libcompiler-rt" ];then                    \
+		rm -rf $(LLVM_REPO)/build_libcompiler-rt;                     \
+	fi
+	cd $(LLVM_REPO)  &&                                                   \
+	mkdir build_libcompiler-rt && cd build_libcompiler-rt  &&             \
+	cmake  -D musl=Yes                                                    \
+		-D CMAKE_BUILD_TYPE=Release                                   \
+		-D LLVM_CONFIG_PATH=$(LLVM_BUILD)/bin/llvm-config             \
+		-D COMPILER_RT_DEFAULT_TARGET_ONLY=ON                         \
+		-D COMPILER_RT_BUILD_BUILTINS=ON                              \
+		-D COMPILER_RT_BUILD_SANITIZERS=OFF                           \
+		-D COMPILER_RT_BUILD_XRAY=OFF                                 \
+		-D COMPILER_RT_BUILD_LIBFUZZER=OFF                            \
+		-D COMPILER_RT_BUILD_PROFILE=OFF                              \
+		-D CMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)                     \
+		-D CMAKE_INSTALL_PREFIX=$(LLVM)                               \
+		../compiler-rt &&                                             \
+	make -j 8 &&                                                          \
+	make install
+
+$(LLVM)/lib/linux/clang_rt.crtbegin-x86_64.o: libcompiler-rt.a
+$(LLVM)/lib/linux/clang_rt.crtend-x86_64.o: libcompiler-rt.a
+
+$(LLVM)/lib/linux/clang_rt.crtbegin-x86_64.o.elf: $(LLVM)/lib/linux/clang_rt.crtbegin-x86_64.o
+	repo2obj --repo=$(LLVM_REPO)/build_libcompiler-rt/lib/crt/clang.db $< -o $@
+
+$(LLVM)/lib/linux/clang_rt.crtend-x86_64.o.elf: $(LLVM)/lib/linux/clang_rt.crtend-x86_64.o
+	repo2obj --repo=$(LLVM_REPO)/build_libcompiler-rt/lib/crt/clang.db $< -o $@
+
+libcxxabi.a:
+	if [ -d "$(LLVM_REPO)/build_libcxxabi" ];then                               \
+		rm -rf $(LLVM_REPO)/build_libcxxabi;                                \
+	fi
+	cd $(LLVM_REPO) &&                                                          \
+	mkdir build_libcxxabi && cd build_libcxxabi  &&                             \
+	cmake -D musl=Yes                                                           \
+		-D CMAKE_BUILD_TYPE=Release                                         \
+		-D libcxxabi_include=-I$(LLVM_BUILD)/lib/clang/11.0.0/include/      \
+		-D LIBCXXABI_ENABLE_EXCEPTIONS=OFF                                  \
+		-D LLVM_PATH=../                                                    \
+		-D LIBCXXABI_USE_COMPILER_RT=YES                                    \
+		-D LIBCXXABI_ENABLE_SHARED=No                                       \
+		-D LIBCXXABI_ENABLE_STATIC=Yes                                      \
+		-D CMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)                           \
+		-D CMAKE_INSTALL_PREFIX=$(LLVM)                                     \
+		../libcxxabi &&                                                     \
+	make -j 8 &&                                                                \
+	make install
+
+libcxx.a: libcxxabi.a
+	if [ -d "$(LLVM_REPO)/build_libcxx" ];then                            \
+		rm -rf $(LLVM_REPO)/build_libcxx;                             \
+	fi
+	cd $(LLVM_REPO)  &&                                                   \
+	mkdir build_libcxx && cd build_libcxx  &&                             \
+	cmake -D musl=Yes  -D libcxx=Yes                                      \
+		-D CMAKE_BUILD_TYPE=Release                                   \
+		-D LIBCXX_ENABLE_SHARED=No                                    \
+		-D LIBCXX_ENABLE_STATIC=Yes                                   \
+		-D LIBCXX_CXX_ABI=libcxxabi                                   \
+		-D LIBCXX_CXX_ABI_INCLUDE_PATHS=../libcxxabi/include          \
+		-D LIBCXX_HAS_MUSL_LIBC=ON                                    \
+		-D CMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)                     \
+		-D CMAKE_INSTALL_PREFIX=$(LLVM)                               \
+		../libcxx &&                                                  \
+	make -j 8 &&                                                          \
+	make install
+
+.PHONY: all
+all :
+	$(MAKE) libunwind.a \
+		libcompiler-rt.a \
+		libcxxabi.a \
+		libcxx.a \
+		$(LLVM)/lib/linux/clang_rt.crtbegin-x86_64.o.elf \
+		$(LLVM)/lib/linux/clang_rt.crtend-x86_64.o.elf
+
+.PHONY: clean
+clean:
+	-rm -rf "$(LLVM_REPO)/build_libunwind"                \
+			"$(LLVM_REPO)/build_libcompiler-rt"   \
+			"$(LLVM_REPO)/build_libcxx"           \
+			"$(LLVM_REPO)/build_libcxx"
+
+.PHONY: distclean
+distclean: clean
+	-rm -f clang.db

--- a/llvm/utils/repo/repo.cmake
+++ b/llvm/utils/repo/repo.cmake
@@ -15,6 +15,9 @@ set (triple "x86_64-pc-linux-gnu-repo")
 SET (CMAKE_C_COMPILER   "clang"  CACHE FILEPATH "Compiler")
 SET (CMAKE_CXX_COMPILER "clang++"  CACHE FILEPATH "Compiler")
 
+option(libcxx "Build the project using the LLVM libc++ library." OFF)
+option(musl "Build the project using the musl libc library." OFF)
+
 # The user may specify the utils_dir by giving
 # '-Dutils_dir:STRING=/path/to/llvm/utils/repo' on the command line
 if (utils_dir)
@@ -24,10 +27,52 @@ else ()
     set (utils_dir /usr/share/repo)
 endif ()
 
-SET (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -fno-exceptions -fno-rtti" CACHE STRING "Default C Flags Debug")
-SET (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -fno-exceptions -fno-rtti" CACHE STRING "Default CXX Flags Debug")
-SET (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -fno-exceptions -fno-rtti" CACHE STRING "Default C Flags Release")
-SET (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -fno-exceptions -fno-rtti" CACHE STRING "Default CXX Flags Release")
+# libcxxabi_include: the path of the directory containing the clang's include files.
+# The user may specify the libcxxabi_include by giving
+# '-Dlibcxxabi_include:STRING=/path/to/clang/include' on the command line.
+if (libcxxabi_include)
+	set (libcxxabi_include "${libcxxabi_include}")
+endif ()
+
+# musl_install: the path of the directory in which musl libc is installed.
+# The user may specify the musl_install by giving
+# '-Dmusl_install:STRING=/path/to/musl/installed/directory' on the command line.
+if (musl_install)
+	set (musl_install "${musl_install}")
+else ()
+	set (musl_install "/home/prepo/musl")
+endif ()
+
+# llvm_install: the path of the directory in which llvm libraries are installed.
+# The user may specify the llvm_install by giving
+# '-Dllvm_install:STRING=/path/to/llvm/installed/directory' on the command line.
+if (llvm_install)
+	set (llvm_install "${llvm_install}")
+else ()
+	set (llvm_install "/home/prepo/LLVM")
+endif ()
+
+# The user may use the LLVM libc++.a by giving
+# '-Dlibcxx:BOOL=Yes' on the command line
+if (libcxx)
+	set (libcxx_flags "-stdlib=libc++")
+	set (libcxxabi_lib "-L ${llvm_install}/lib -stdlib=libc++ -lc++abi")
+endif()
+
+# The user may use the MUSL libc.a by giving
+# '-Dmusl:BOOL=Yes' on the command line
+if (musl)
+	SET (musl_compile_flags "-nostdinc -nostdinc++ --sysroot ${musl_install} -isystem ${musl_install}/include ${libcxxabi_include}")
+	SET (CMAKE_EXE_LINKER_FLAGS "-nostdlib -nodefaultlibs -static --sysroot ${musl_install} -L ${musl_install}/lib ${libcxxabi_lib} -lc_elf" CACHE STRING "toolchain_exelinkflags" FORCE)
+endif()
+
+SET (CMAKE_C_FLAGS "${musl_compile_flags} -fno-exceptions -fno-rtti" CACHE STRING "toolchain_cflags")
+SET (CMAKE_CXX_FLAGS "${musl_compile_flags} ${libcxx_flags} -fno-exceptions -fno-rtti" CACHE STRING "toolchain_cxxflags")
+
+SET (CMAKE_C_FLAGS_DEBUG " -O0 " CACHE STRING "Default C Flags Debug")
+SET (CMAKE_CXX_FLAGS_DEBUG " -O0 " CACHE STRING "Default CXX Flags Debug")
+SET (CMAKE_C_FLAGS_RELEASE " -O3 " CACHE STRING "Default C Flags Release")
+SET (CMAKE_CXX_FLAGS_RELEASE " -O3 " CACHE STRING "Default CXX Flags Release")
 set (CMAKE_C_COMPILER_TARGET ${triple})
 set (CMAKE_CXX_COMPILER_TARGET ${triple})
 
@@ -37,7 +82,6 @@ set (CMAKE_CXX_LINKER ${CMAKE_LINKER})
 
 set (CMAKE_C_LINK_EXECUTABLE "${utils_dir}/link.py <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
 set (CMAKE_CXX_LINK_EXECUTABLE "${utils_dir}/link.py <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
-
 
 set (CMAKE_C_CREATE_SHARED_LIBRARY   "${utils_dir}/link.py <FLAGS> <CMAKE_SHARED_LIBRARY_C_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")
 set (CMAKE_CXX_CREATE_SHARED_LIBRARY "${utils_dir}/link.py <FLAGS> <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")


### PR DESCRIPTION
After porting the musl-libc to the program repository, we want to use the musl-libc to build the project. The repo.cmake file is modified to support of building the project using musl libc library and the LLVM libc++ library.