### PR TITLE
repo-fragments now returns 1 (failure) if a requested name is not found

### DIFF
--- a/llvm/test/tools/repo-fragments/tool-options-test.ll
+++ b/llvm/test/tools/repo-fragments/tool-options-test.ll
@@ -14,6 +14,9 @@
 ; RUN: repo-fragments -repo=%t.db -c %t.o | FileCheck --check-prefix=COMMA %s
 ; RUN: repo-fragments -repo=%t.db -c %t.o f | FileCheck --check-prefix=NAME --match-full-lines --strict-whitespace %s
 ;
+; Try a name that is not present in the compilation.
+; RUN: NOT repo-fragments -repo=%t.db %t.o missing
+;
 ; BASIC: f: {{([[:xdigit:]]{32})}}
 ; BASIC: v: {{([[:xdigit:]]{32})}}
 ; VONLY-NOT: f: {{([[:xdigit:]]{32})}}

--- a/llvm/tools/repo-fragments/RepoFragments.cpp
+++ b/llvm/tools/repo-fragments/RepoFragments.cpp
@@ -139,6 +139,7 @@ int main(int argc, char *argv[]) {
   };
 
   const auto *Sep = "";
+  const auto *End = "";
   auto const Compilation =
       pstore::repo::compilation::load(Db, CompilationPos->second);
   for (auto const &CM : *Compilation) {
@@ -152,9 +153,10 @@ int main(int argc, char *argv[]) {
     // Dump this digest (and perhaps name) if it was requested by the user.
     if (IsRequestedName(MemberNameRef)) {
       outs() << Sep << makeNameAndDigest(DigestOnly, MemberNameRef, CM.digest);
+      End = "\n";
       Sep = UseComma ? "," : "\n";
     }
   }
-  outs() << '\n';
+  outs() << End;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
There are two ways to use repo-fragments. One is to pass it a ticket file path and it will dump all of the names defined therein. The second way is to also pass one or more additional strings: this will limit the output to just those names.

In the latter case I would like the tool to return failure if a filter name is not present in the compilation. This then makes it much easier to find which ticket(s) are responsible for the definition of a known name. It’s as easy as something like:

~~~bash
find . -name \*.o -exec repo-fragments {} foo \; -print
~~~

This will search the directory tree starting at the current working directory for files named *.o. For each one found, it will run repo-fragments. If this returns success — which it will do if the compilation contains a definition named ‘foo’ — the name of the file is printed.

A useful tool when understanding the reasons for a link failure.

([This wiki page](https://github.com/SNSystems/llvm-project-prepo/wiki/Exploring-a-Program-Repository) discusses other further ways in which repo-fragments can be used to explore a program repository.)