### PR TITLE
Fixed a previous merge issue and a test failure.

### DIFF
--- a/llvm/lib/Target/Lanai/LanaiTargetObjectFile.cpp
+++ b/llvm/lib/Target/Lanai/LanaiTargetObjectFile.cpp
@@ -117,8 +117,8 @@ bool LanaiTargetObjectFile::isConstantInSmallSection(const DataLayout &DL,
 }
 
 MCSection *LanaiTargetObjectFile::getSectionForConstant(
-    const DataLayout &DL, SectionKind Kind, const Constant *C,
-    const GlobalObject *GO, Align &Alignment) const {
+    const DataLayout &DL, SectionKind Kind, const Constant *C, Align &Alignment,
+    const GlobalObject *GO) const {
   if (isConstantInSmallSection(DL, C))
     return SmallDataSection;
 

--- a/llvm/test/tools/repo-fragments/tool-options-test.ll
+++ b/llvm/test/tools/repo-fragments/tool-options-test.ll
@@ -15,7 +15,7 @@
 ; RUN: repo-fragments -repo=%t.db -c %t.o f | FileCheck --check-prefix=NAME --match-full-lines --strict-whitespace %s
 ;
 ; Try a name that is not present in the compilation.
-; RUN: NOT repo-fragments -repo=%t.db %t.o missing
+; RUN: not repo-fragments -repo=%t.db %t.o missing
 ;
 ; BASIC: f: {{([[:xdigit:]]{32})}}
 ; BASIC: v: {{([[:xdigit:]]{32})}}


### PR DESCRIPTION
To reproduce the build error, target on all targets:
```
$ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang;pstore" -DLLVM_TOOL_CLANG_TOOLS_EXTRA_BUILD=OFF ../llvm
$ ninja
```
Got a build error:
```
/home/maggie/github/llvm-project-prepo/llvm/lib/Target/Lanai/LanaiTargetObjectFile.cpp:119:12: error: no declaration matches ‘llvm::MCSection* llvm::LanaiTargetObjectFile::getSectionForConstant(const llvm::DataLayout&, llvm::SectionKind, const llvm::Constant*, const llvm::GlobalObject*, llvm::Align&) const’
  119 | MCSection *LanaiTargetObjectFile::getSectionForConstant(
```

When running the lit tests, a test failed with the following error:
```
$ ninja check-all

LLVM :: tools/repo-fragments/tool-options-test.ll

Error: NOT command not found
```