### PR TITLE
Use section_kind::last rather than member_array::max_size()

### DIFF
--- a/llvm/tools/repo2obj/repo2obj.cpp
+++ b/llvm/tools/repo2obj/repo2obj.cpp
@@ -464,7 +464,8 @@ int main(int argc, char *argv[]) {
       Prefixes;
   {
     std::vector<OutputSection<ELFT>::SectionInfo> OutputSections;
-    OutputSections.resize(::pstore::repo::fragment::member_array::max_size());
+    OutputSections.resize(
+        static_cast<std::size_t>(pstore::repo::section_kind::last));
 
     Optional<pstore::extent<std::uint8_t>> DebugLineHeaderExtent;
     auto Compilation =


### PR DESCRIPTION
pstore [PR#98](https://github.com/SNSystems/pstore/pull/98) removes the max_size() function from member_array. This change removes the call and follows the precedent set by the declaration of `Prefixes` a couple of lines earlier.