### PR TITLE
Remove the unused compilation warning.

### DIFF
--- a/llvm/utils/repo/Makefile
+++ b/llvm/utils/repo/Makefile
@@ -29,6 +29,8 @@ libunwind.a:
 		-D LIBUNWIND_ENABLE_STATIC=Yes                                \
 		-D LLVM_ENABLE_UNWIND_TABLES=OFF                              \
 		-D CMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)                     \
+		-D CMAKE_CXX_COMPILER=$(LLVM_BUILD)/bin/clang++               \
+		-D CMAKE_C_COMPILER=$(LLVM_BUILD)/bin/clang                   \
 		-D CMAKE_INSTALL_PREFIX=$(LLVM)                               \
 		-D musl_install=$(MUSL)                                       \
 		../libunwind &&                                               \
@@ -52,6 +54,8 @@ libcompiler-rt.a:
 		-D COMPILER_RT_BUILD_PROFILE=OFF                              \
 		-D LLVM_ENABLE_UNWIND_TABLES=OFF                              \
 		-D CMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)                     \
+		-D CMAKE_CXX_COMPILER=$(LLVM_BUILD)/bin/clang++               \
+		-D CMAKE_C_COMPILER=$(LLVM_BUILD)/bin/clang                   \
 		-D CMAKE_INSTALL_PREFIX=$(LLVM)                               \
 		-D musl_install=$(MUSL)                                       \
 		../compiler-rt &&                                             \
@@ -84,6 +88,8 @@ libcxxabi.a: libunwind.a libcompiler-rt.a                                       
 		-D LIBCXXABI_ENABLE_SHARED=No                                       \
 		-D LIBCXXABI_ENABLE_STATIC=Yes                                      \
 		-D CMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)                           \
+		-D CMAKE_CXX_COMPILER=$(LLVM_BUILD)/bin/clang++                     \
+		-D CMAKE_C_COMPILER=$(LLVM_BUILD)/bin/clang                         \
 		-D LLVM_ENABLE_UNWIND_TABLES=OFF                                    \
 		-D CMAKE_INSTALL_PREFIX=$(LLVM)                                     \
 		-D musl_install=$(MUSL)                                             \
@@ -106,6 +112,8 @@ libcxx.a: libcxxabi.a
 		-D LIBCXX_HAS_MUSL_LIBC=ON                                    \
 		-D LLVM_ENABLE_UNWIND_TABLES=OFF                              \
 		-D CMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)                     \
+		-D CMAKE_CXX_COMPILER=$(LLVM_BUILD)/bin/clang++               \
+		-D CMAKE_C_COMPILER=$(LLVM_BUILD)/bin/clang                   \
 		-D CMAKE_INSTALL_PREFIX=$(LLVM)                               \
 		-D musl_install=$(MUSL)                                       \
 		../libcxx &&                                                  \

--- a/llvm/utils/repo/repo.cmake
+++ b/llvm/utils/repo/repo.cmake
@@ -55,20 +55,20 @@ endif ()
 # The user may use the LLVM libc++.a by giving
 # '-Dlibcxx:BOOL=Yes' on the command line
 if (libcxx)
-	set (libcxx_flags "-stdlib=libc++ -isystem ${llvm_install}/include/c++/v1 -isystem ${llvm_install}/lib/clang/11.0.0/include")
-	set (libcxxabi_lib "-stdlib=libc++ -L ${llvm_install}/lib ${llvm_install}/lib/linux/clang_rt.crtbegin-x86_64.o.elf ${llvm_install}/lib/linux/clang_rt.crtend-x86_64.o.elf -lc++ -lc++abi -L ${llvm_install}/lib/linux -lclang_rt.builtins-x86_64")
+	set (libcxx_compile_flags "-nostdinc++ -isystem ${llvm_install}/include/c++/v1 -isystem ${llvm_install}/lib/clang/11.0.0/include")
+	set (libcxx_link_flags "-nostdlib++ -L ${llvm_install}/lib ${llvm_install}/lib/linux/clang_rt.crtbegin-x86_64.o.elf ${llvm_install}/lib/linux/clang_rt.crtend-x86_64.o.elf -lc++ -lc++abi -L ${llvm_install}/lib/linux -lclang_rt.builtins-x86_64")
 endif()
 
 # The user may use the MUSL libc.a by giving
 # '-Dmusl:BOOL=Yes' on the command line
 if (musl)
-	SET (musl_compile_flags "-D__MUSL__ -nostdinc -nostdinc++ --sysroot ${musl_install} -isystem ${musl_install}/include ${libcxxabi_include}")
+	SET (musl_compile_flags "-D__MUSL__ -nostdinc --sysroot ${musl_install} -isystem ${musl_install}/include ${libcxxabi_include}")
 	SET (musl_crt "${musl_install}/lib/crt1.t.o ${musl_install}/lib/crt1_asm.t.o")
-	SET (CMAKE_EXE_LINKER_FLAGS "-nostdlib -nodefaultlibs -static --sysroot ${musl_install} -L ${musl_install}/lib ${libcxxabi_lib} -lc_elf" CACHE STRING "toolchain_exelinkflags" FORCE)
+	SET (CMAKE_EXE_LINKER_FLAGS "-nostdlib -nodefaultlibs -static --sysroot ${musl_install} -L ${musl_install}/lib ${libcxx_link_flags} -lc_elf" CACHE STRING "toolchain_exelinkflags" FORCE)
 endif()
 
-SET (CMAKE_C_FLAGS "${musl_compile_flags} -fno-exceptions -fno-rtti" CACHE STRING "toolchain_cflags")
-SET (CMAKE_CXX_FLAGS "${libcxx_flags} ${musl_compile_flags} -fno-exceptions -fno-rtti" CACHE STRING "toolchain_cxxflags")
+SET (CMAKE_C_FLAGS "${musl_compile_flags} -fno-exceptions -fno-rtti -fno-unwind-tables" CACHE STRING "toolchain_cflags")
+SET (CMAKE_CXX_FLAGS "${libcxx_compile_flags} ${musl_compile_flags} -fno-exceptions -fno-rtti -fno-unwind-tables" CACHE STRING "toolchain_cxxflags")
 
 SET (CMAKE_C_FLAGS_DEBUG " -O0 " CACHE STRING "Default C Flags Debug")
 SET (CMAKE_CXX_FLAGS_DEBUG " -O0 " CACHE STRING "Default CXX Flags Debug")


### PR DESCRIPTION
When I built the clang and pstore project using repo-based libraries and repo.cmake, 
I got the following error.
```
Remove the warning: “clang: warning: argument unused during compilation: '-stdlib=libc++'  [-Wunused-command-line-argument].
```


On systems where libc++ is provided but is not the default, Clang provides a flag called
-stdlib= that can be used to decide which standard library is used. Using -stdlib=libc++
will select libc++. However, we use a custom built libc++ library.  Clang provides a way
to disable the default behavior for finding the standard library and to override it with
custom paths. This can be done with:
“-nostdinc++ -nostdlib++ -isystem \<install\>/include/c++/v1 -L \<install\>/lib -lc++”.

This commit includes:
1. Fixed the warning.
2. Since the unwind table section isn't supported on repo target yet.
add the -fno-unwind-tables to the compile flags.