### PR TITLE
Install the repo-based LLVM libraries and database.

### DIFF
--- a/llvm/utils/repo/Makefile
+++ b/llvm/utils/repo/Makefile
@@ -8,7 +8,12 @@
 
 # The path of the directory in which llvm-project-prepo sources is checked out from git.
 LLVM_REPO = ${HOME}/llvm-project-prepo
-TOOLCHAIN_FILE=$(LLVM_REPO)/llvm/utils/repo/repo.cmake
+# Choose the toolchina file to be used. By default, repo.cmake is used.
+ifdef FULL_REPO
+	TOOLCHAIN_FILE=$(LLVM_REPO)/llvm/utils/repo/full_repo.cmake
+else
+	TOOLCHAIN_FILE=$(LLVM_REPO)/llvm/utils/repo/repo.cmake
+endif
 # The path of the llvm-project-prepo build directory.
 LLVM_BUILD = ${LLVM_REPO}/build
 # The path of the directory in which llvm libraries are installed.
@@ -22,6 +27,7 @@ libunwind.a:
 	fi
 	cd $(LLVM_REPO)  &&                                                   \
 	mkdir build_libunwind && cd build_libunwind  &&                       \
+	export REPOFILE=$(LLVM_REPO)/build_libunwind/libunwind.db &&          \
 	cmake -D musl=Yes                                                     \
 		-D CMAKE_BUILD_TYPE=Release                                   \
 		-D LLVM_PATH=../                                              \
@@ -31,6 +37,7 @@ libunwind.a:
 		-D CMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)                     \
 		-D CMAKE_CXX_COMPILER=$(LLVM_BUILD)/bin/clang++               \
 		-D CMAKE_C_COMPILER=$(LLVM_BUILD)/bin/clang                   \
+		-D utils_dir=$(LLVM_REPO)/llvm/utils/repo                     \
 		-D CMAKE_INSTALL_PREFIX=$(LLVM)                               \
 		-D musl_install=$(MUSL)                                       \
 		../libunwind &&                                               \
@@ -43,6 +50,7 @@ libcompiler-rt.a:
 	fi
 	cd $(LLVM_REPO)  &&                                                   \
 	mkdir build_libcompiler-rt && cd build_libcompiler-rt  &&             \
+	export REPOFILE=$(LLVM_REPO)/build_libcompiler-rt/libcompiler-rt.db &&\
 	cmake  -D musl=Yes                                                    \
 		-D CMAKE_BUILD_TYPE=Release                                   \
 		-D LLVM_CONFIG_PATH=$(LLVM_BUILD)/bin/llvm-config             \
@@ -56,6 +64,7 @@ libcompiler-rt.a:
 		-D CMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)                     \
 		-D CMAKE_CXX_COMPILER=$(LLVM_BUILD)/bin/clang++               \
 		-D CMAKE_C_COMPILER=$(LLVM_BUILD)/bin/clang                   \
+		-D utils_dir=$(LLVM_REPO)/llvm/utils/repo                     \
 		-D CMAKE_INSTALL_PREFIX=$(LLVM)                               \
 		-D musl_install=$(MUSL)                                       \
 		../compiler-rt &&                                             \
@@ -66,10 +75,10 @@ $(LLVM)/lib/linux/clang_rt.crtbegin-x86_64.o: libcompiler-rt.a
 $(LLVM)/lib/linux/clang_rt.crtend-x86_64.o: libcompiler-rt.a
 
 $(LLVM)/lib/linux/clang_rt.crtbegin-x86_64.o.elf: $(LLVM)/lib/linux/clang_rt.crtbegin-x86_64.o
-	repo2obj --repo=$(LLVM_REPO)/build_libcompiler-rt/lib/crt/clang.db $< -o $@
+	repo2obj --repo=$(LLVM_REPO)/build_libcompiler-rt/libcompiler-rt.db $< -o $@
 
 $(LLVM)/lib/linux/clang_rt.crtend-x86_64.o.elf: $(LLVM)/lib/linux/clang_rt.crtend-x86_64.o
-	repo2obj --repo=$(LLVM_REPO)/build_libcompiler-rt/lib/crt/clang.db $< -o $@
+	repo2obj --repo=$(LLVM_REPO)/build_libcompiler-rt/libcompiler-rt.db $< -o $@
 
 libcxxabi.a: libunwind.a libcompiler-rt.a                                          \
              $(LLVM)/lib/linux/clang_rt.crtbegin-x86_64.o.elf                      \
@@ -79,6 +88,7 @@ libcxxabi.a: libunwind.a libcompiler-rt.a                                       
 	fi
 	cd $(LLVM_REPO) &&                                                          \
 	mkdir build_libcxxabi && cd build_libcxxabi  &&                             \
+	export REPOFILE=$(LLVM_REPO)/build_libcxxabi/libc++abi.db &&                \
 	cmake -D musl=Yes                                                           \
 		-D CMAKE_BUILD_TYPE=Release                                         \
 		-D libcxxabi_include=-I$(LLVM_BUILD)/lib/clang/11.0.0/include/      \
@@ -91,6 +101,7 @@ libcxxabi.a: libunwind.a libcompiler-rt.a                                       
 		-D CMAKE_CXX_COMPILER=$(LLVM_BUILD)/bin/clang++                     \
 		-D CMAKE_C_COMPILER=$(LLVM_BUILD)/bin/clang                         \
 		-D LLVM_ENABLE_UNWIND_TABLES=OFF                                    \
+		-D utils_dir=$(LLVM_REPO)/llvm/utils/repo                           \
 		-D CMAKE_INSTALL_PREFIX=$(LLVM)                                     \
 		-D musl_install=$(MUSL)                                             \
 		../libcxxabi &&                                                     \
@@ -103,6 +114,7 @@ libcxx.a: libcxxabi.a
 	fi
 	cd $(LLVM_REPO)  &&                                                   \
 	mkdir build_libcxx && cd build_libcxx  &&                             \
+	export REPOFILE=$(LLVM_REPO)/build_libcxx/libc++.db &&                \
 	cmake -D musl=Yes                                                     \
 		-D CMAKE_BUILD_TYPE=Release                                   \
 		-D LIBCXX_ENABLE_SHARED=No                                    \
@@ -114,26 +126,46 @@ libcxx.a: libcxxabi.a
 		-D CMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)                     \
 		-D CMAKE_CXX_COMPILER=$(LLVM_BUILD)/bin/clang++               \
 		-D CMAKE_C_COMPILER=$(LLVM_BUILD)/bin/clang                   \
+		-D utils_dir=$(LLVM_REPO)/llvm/utils/repo                     \
 		-D CMAKE_INSTALL_PREFIX=$(LLVM)                               \
 		-D musl_install=$(MUSL)                                       \
 		../libcxx &&                                                  \
 	make -j 8 &&                                                          \
 	make install
 
-.PHONY: all
-all :
-	$(MAKE) libunwind.a \
-		libcompiler-rt.a \
-		libcxxabi.a \
-		libcxx.a
+$(LLVM)/lib/libunwind.db: libunwind.a
+	cp $(LLVM_REPO)/build_libunwind/libunwind.db $@
+
+$(LLVM)/lib/linux/libcompiler-rt.db: libcompiler-rt.a
+	cp $(LLVM_REPO)/build_libcompiler-rt/libcompiler-rt.db $@
+
+$(LLVM)/lib/libc++abi.db: libcxxabi.a
+	cp $(LLVM_REPO)/build_libcxxabi/libc++abi.db $@
+
+$(LLVM)/lib/libc++.db: libcxx.a
+	cp $(LLVM_REPO)/build_libcxx/libc++.db $@
+
+install-libs: libunwind.a \
+	libcompiler-rt.a \
+	libcxxabi.a \
+	libcxx.a
+
+install-repo-libs-dbs: $(LLVM)/lib/libunwind.db \
+	$(LLVM)/lib/linux/libcompiler-rt.db \
+	$(LLVM)/lib/libc++abi.db \
+	$(LLVM)/lib/libc++.db
+
+.PHONY: install
+install:
+ifdef FULL_REPO
+	$(MAKE) install-repo-libs-dbs
+else
+	$(MAKE) install-libs
+endif
 
 .PHONY: clean
 clean:
 	-rm -rf "$(LLVM_REPO)/build_libunwind"                \
 			"$(LLVM_REPO)/build_libcompiler-rt"   \
-			"$(LLVM_REPO)/build_libcxx"           \
+			"$(LLVM_REPO)/build_libcxxabi"        \
 			"$(LLVM_REPO)/build_libcxx"
-
-.PHONY: distclean
-distclean: clean
-	-rm -f clang.db

--- a/llvm/utils/repo/full_repo.cmake
+++ b/llvm/utils/repo/full_repo.cmake
@@ -1,0 +1,96 @@
+#===- full_repo.cmake ---------------------------------------------------------===
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM
+# Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===----------------------------------------------------------------------===
+
+SET (CMAKE_SYSTEM_VERSION 1)
+SET (CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set (triple "x86_64-pc-linux-gnu-repo")
+
+SET (CMAKE_C_COMPILER   "clang"  CACHE FILEPATH "Compiler")
+SET (CMAKE_CXX_COMPILER "clang++"  CACHE FILEPATH "Compiler")
+
+option(libcxx "Build the project using the LLVM libc++ library." OFF)
+option(musl "Build the project using the musl libc library." OFF)
+
+# The user may specify the utils_dir by giving
+# '-Dutils_dir:STRING=/path/to/llvm/utils/repo' on the command line
+if (utils_dir)
+    # Environment variables are always preserved.
+    set(ENV{_utils_dir} "${utils_dir}")
+else ()
+    set (utils_dir /usr/share/repo)
+endif ()
+
+# libcxxabi_include: the path of the directory containing the clang's include files.
+# The user may specify the libcxxabi_include by giving
+# '-Dlibcxxabi_include:STRING=/path/to/clang/include' on the command line.
+if (libcxxabi_include)
+	set (libcxxabi_include "${libcxxabi_include}")
+endif ()
+
+# musl_install: the path of the directory in which musl libc is installed.
+# The user may specify the musl_install by giving
+# '-Dmusl_install:STRING=/path/to/musl/installed/directory' on the command line.
+if (musl_install)
+	set (musl_install "${musl_install}")
+else ()
+	set (musl_install "/home/prepo/musl")
+endif ()
+
+# llvm_install: the path of the directory in which llvm libraries are installed.
+# The user may specify the llvm_install by giving
+# '-Dllvm_install:STRING=/path/to/llvm/installed/directory' on the command line.
+if (llvm_install)
+	set (llvm_install "${llvm_install}")
+else ()
+	set (llvm_install "/home/prepo/LLVM")
+endif ()
+
+# The user may use the LLVM libc++.a by giving
+# '-Dlibcxx:BOOL=Yes' on the command line
+if (libcxx)
+	set (libcxx_compile_flags "-nostdinc++ -isystem ${llvm_install}/include/c++/v1 -isystem ${llvm_install}/lib/clang/11.0.0/include")
+	set (libcxx_link_flags "-nostdlib++ -L ${llvm_install}/lib ${llvm_install}/lib/linux/clang_rt.crtbegin-x86_64.o.elf ${llvm_install}/lib/linux/clang_rt.crtend-x86_64.o.elf -lc++ -lc++abi -L ${llvm_install}/lib/linux -lclang_rt.builtins-x86_64")
+endif()
+
+# The user may use the MUSL libc.a by giving
+# '-Dmusl:BOOL=Yes' on the command line
+if (musl)
+	SET (musl_compile_flags "-D__MUSL__ -nostdinc --sysroot ${musl_install} -isystem ${musl_install}/include ${libcxxabi_include}")
+	SET (musl_crt "${musl_install}/lib/crt1.t.o ${musl_install}/lib/crt1_asm.t.o")
+	SET (CMAKE_EXE_LINKER_FLAGS "-nostdlib -nodefaultlibs -static --sysroot ${musl_install} -L ${musl_install}/lib ${libcxx_link_flags} -lc_elf" CACHE STRING "toolchain_exelinkflags" FORCE)
+endif()
+
+SET (CMAKE_C_FLAGS "${musl_compile_flags} -fno-exceptions -fno-rtti -fno-unwind-tables" CACHE STRING "toolchain_cflags")
+SET (CMAKE_CXX_FLAGS "${libcxx_compile_flags} ${musl_compile_flags} -fno-exceptions -fno-rtti -fno-unwind-tables" CACHE STRING "toolchain_cxxflags")
+
+SET (CMAKE_C_FLAGS_DEBUG " -O0 " CACHE STRING "Default C Flags Debug")
+SET (CMAKE_CXX_FLAGS_DEBUG " -O0 " CACHE STRING "Default CXX Flags Debug")
+SET (CMAKE_C_FLAGS_RELEASE " -O3 " CACHE STRING "Default C Flags Release")
+SET (CMAKE_CXX_FLAGS_RELEASE " -O3 " CACHE STRING "Default CXX Flags Release")
+set (CMAKE_C_COMPILER_TARGET ${triple})
+set (CMAKE_CXX_COMPILER_TARGET ${triple})
+
+# TODO: once rld works for C++ constructor/destructor, we will set CMAKE_LINKER to rld.
+# The link.py should be used together with archive.py. To pass the cmake default tests
+# to generate the project, the link.py is temporarily used.
+set (CMAKE_LINKER ${utils_dir}/link.py)
+set (CMAKE_C_LINKER ${CMAKE_LINKER})
+set (CMAKE_CXX_LINKER ${CMAKE_LINKER})
+
+set (CMAKE_C_LINK_EXECUTABLE "${utils_dir}/link.py <FLAGS> <CMAKE_C_LINK_FLAGS> ${musl_crt} <OBJECTS> <LINK_LIBRARIES> <LINK_FLAGS> -o <TARGET>")
+set (CMAKE_CXX_LINK_EXECUTABLE "${utils_dir}/link.py <FLAGS> <CMAKE_CXX_LINK_FLAGS> ${musl_crt} <OBJECTS> <LINK_LIBRARIES> <LINK_FLAGS> -o <TARGET>")
+
+set (CMAKE_C_CREATE_SHARED_LIBRARY   "${utils_dir}/link.py <FLAGS> <CMAKE_SHARED_LIBRARY_C_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")
+set (CMAKE_CXX_CREATE_SHARED_LIBRARY "${utils_dir}/link.py <FLAGS> <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")
+
+set (CMAKE_FIND_LIBRARY_PREFIXES "")
+set (CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+
+# eof: full_repo.cmake


### PR DESCRIPTION
Current, only LLVM ELF libraries (using repo2obj) are installed.

This commit includes:

1. rename the ELF libraries from `name.a` to `name_elf.a`.
2. install the repo based LLVM libraries and the corresponding databases.
3. repo wrap tool generates both repo and elf libraries.