### PR TITLE
Add Repo toolchain support for the musl-repo target in the clang Driver.

### DIFF
--- a/clang/lib/Driver/CMakeLists.txt
+++ b/clang/lib/Driver/CMakeLists.txt
@@ -65,6 +65,7 @@ add_clang_library(clangDriver
   ToolChains/NetBSD.cpp
   ToolChains/OpenBSD.cpp
   ToolChains/PS4CPU.cpp
+  ToolChains/Repo.cpp
   ToolChains/RISCVToolchain.cpp
   ToolChains/Solaris.cpp
   ToolChains/TCE.cpp

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -40,6 +40,7 @@
 #include "ToolChains/OpenBSD.h"
 #include "ToolChains/PPCLinux.h"
 #include "ToolChains/PS4CPU.h"
+#include "ToolChains/Repo.h"
 #include "ToolChains/RISCVToolchain.h"
 #include "ToolChains/Solaris.h"
 #include "ToolChains/TCE.h"
@@ -4938,7 +4939,9 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
                                                               Args);
       else if (Target.getArch() == llvm::Triple::ve)
         TC = std::make_unique<toolchains::VEToolChain>(*this, Target, Args);
-
+      else if (Target.getObjectFormat() == llvm::Triple::Repo &&
+               Target.getEnvironment() == llvm::Triple::Musl)
+        TC = std::make_unique<toolchains::RepoToolChain>(*this, Target, Args);
       else
         TC = std::make_unique<toolchains::Linux>(*this, Target, Args);
       break;
@@ -5044,6 +5047,9 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
           TC = std::make_unique<toolchains::Generic_ELF>(*this, Target, Args);
         else if (Target.isOSBinFormatMachO())
           TC = std::make_unique<toolchains::MachO>(*this, Target, Args);
+        else if (Target.isOSBinFormatRepo() &&
+                 Target.getEnvironment() == llvm::Triple::Musl)
+          TC = std::make_unique<toolchains::RepoToolChain>(*this, Target, Args);
         else
           TC = std::make_unique<toolchains::Generic_GCC>(*this, Target, Args);
       }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4941,7 +4941,8 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
         TC = std::make_unique<toolchains::VEToolChain>(*this, Target, Args);
       else if (Target.isOSBinFormatRepo() &&
                Target.getEnvironment() == llvm::Triple::Musl)
-        TC = std::make_unique<toolchains::RepoToolChain>(*this, Target, Args);
+        TC = std::make_unique<toolchains::RepoMuslToolChain>(*this, Target,
+                                                             Args);
       else
         TC = std::make_unique<toolchains::Linux>(*this, Target, Args);
       break;
@@ -5049,7 +5050,8 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
           TC = std::make_unique<toolchains::MachO>(*this, Target, Args);
         else if (Target.isOSBinFormatRepo() &&
                  Target.getEnvironment() == llvm::Triple::Musl)
-          TC = std::make_unique<toolchains::RepoToolChain>(*this, Target, Args);
+          TC = std::make_unique<toolchains::RepoMuslToolChain>(*this, Target,
+                                                               Args);
         else
           TC = std::make_unique<toolchains::Generic_GCC>(*this, Target, Args);
       }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4939,8 +4939,7 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
                                                               Args);
       else if (Target.getArch() == llvm::Triple::ve)
         TC = std::make_unique<toolchains::VEToolChain>(*this, Target, Args);
-      else if (Target.getObjectFormat() == llvm::Triple::Repo &&
-               Target.getEnvironment() == llvm::Triple::Musl)
+      else if (Target.getObjectFormat() == llvm::Triple::Repo)
         TC = std::make_unique<toolchains::RepoToolChain>(*this, Target, Args);
       else
         TC = std::make_unique<toolchains::Linux>(*this, Target, Args);
@@ -5047,8 +5046,7 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
           TC = std::make_unique<toolchains::Generic_ELF>(*this, Target, Args);
         else if (Target.isOSBinFormatMachO())
           TC = std::make_unique<toolchains::MachO>(*this, Target, Args);
-        else if (Target.isOSBinFormatRepo() &&
-                 Target.getEnvironment() == llvm::Triple::Musl)
+        else if (Target.isOSBinFormatRepo())
           TC = std::make_unique<toolchains::RepoToolChain>(*this, Target, Args);
         else
           TC = std::make_unique<toolchains::Generic_GCC>(*this, Target, Args);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4939,7 +4939,8 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
                                                               Args);
       else if (Target.getArch() == llvm::Triple::ve)
         TC = std::make_unique<toolchains::VEToolChain>(*this, Target, Args);
-      else if (Target.getObjectFormat() == llvm::Triple::Repo)
+      else if (Target.isOSBinFormatRepo() &&
+               Target.getEnvironment() == llvm::Triple::Musl)
         TC = std::make_unique<toolchains::RepoToolChain>(*this, Target, Args);
       else
         TC = std::make_unique<toolchains::Linux>(*this, Target, Args);
@@ -5046,7 +5047,8 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
           TC = std::make_unique<toolchains::Generic_ELF>(*this, Target, Args);
         else if (Target.isOSBinFormatMachO())
           TC = std::make_unique<toolchains::MachO>(*this, Target, Args);
-        else if (Target.isOSBinFormatRepo())
+        else if (Target.isOSBinFormatRepo() &&
+                 Target.getEnvironment() == llvm::Triple::Musl)
           TC = std::make_unique<toolchains::RepoToolChain>(*this, Target, Args);
         else
           TC = std::make_unique<toolchains::Generic_GCC>(*this, Target, Args);

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -555,6 +555,13 @@ std::string ToolChain::GetLinkerPath() const {
     // second-guess that.
     if (llvm::sys::fs::can_execute(UseLinker))
       return std::string(UseLinker);
+  } else if (Triple.isOSBinFormatRepo()) {
+    llvm::SmallString<8> LinkerName;
+    LinkerName.append("rld");
+
+    std::string LinkerPath(GetProgramPath(LinkerName.c_str()));
+    if (llvm::sys::fs::can_execute(LinkerPath))
+      return LinkerPath;
   } else if (UseLinker.empty() || UseLinker == "ld") {
     // If we're passed -fuse-ld= with no argument, or with the argument ld,
     // then use whatever the default system linker is.

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -556,10 +556,7 @@ std::string ToolChain::GetLinkerPath() const {
     if (llvm::sys::fs::can_execute(UseLinker))
       return std::string(UseLinker);
   } else if (Triple.isOSBinFormatRepo()) {
-    llvm::SmallString<8> LinkerName;
-    LinkerName.append("rld");
-
-    std::string LinkerPath(GetProgramPath(LinkerName.c_str()));
+    std::string LinkerPath(GetProgramPath("rld"));
     if (llvm::sys::fs::can_execute(LinkerPath))
       return LinkerPath;
   } else if (UseLinker.empty() || UseLinker == "ld") {

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -525,6 +525,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       std::string MuslRoot = D.SysRoot.empty() ? "/usr/local/musl" : D.SysRoot;
       CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1.t"));
       CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1_asm.t"));
+      CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/libc_repo.a"));
     }
 
     if (IsVE) {
@@ -537,6 +538,8 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     else if (IsRepo &&
              !Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib)) {
       auto CRTPath = ToolChain.getCompilerRTPath();
+      if (!ToolChain.getVFS().exists(CRTPath))
+        CRTPath = "/usr/lib/linux";
       CmdArgs.push_back(
           Args.MakeArgString(CRTPath + "/clang_rt.crtbegin-x86_64.o"));
       CmdArgs.push_back(

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -405,7 +405,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   const bool HasCRTBeginEndFiles =
       ToolChain.getTriple().hasEnvironment() ||
       (ToolChain.getTriple().getVendor() != llvm::Triple::MipsTechnologies);
-  const bool IsRepo = ToolChain.getTriple().isOSBinFormatRepo();
 
   ArgStringList CmdArgs;
 
@@ -465,17 +464,14 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   ToolChain.addExtraOpts(CmdArgs);
 
-  if (!IsRepo) {
+  CmdArgs.push_back("--eh-frame-hdr");
 
-    CmdArgs.push_back("--eh-frame-hdr");
-
-    if (const char *LDMOption = getLDMOption(ToolChain.getTriple(), Args)) {
-      CmdArgs.push_back("-m");
-      CmdArgs.push_back(LDMOption);
-    } else {
-      D.Diag(diag::err_target_unknown_triple) << Triple.str();
-      return;
-    }
+  if (const char *LDMOption = getLDMOption(ToolChain.getTriple(), Args)) {
+    CmdArgs.push_back("-m");
+    CmdArgs.push_back(LDMOption);
+  } else {
+    D.Diag(diag::err_target_unknown_triple) << Triple.str();
+    return;
   }
 
   if (IsStatic) {
@@ -492,7 +488,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     if (Args.hasArg(options::OPT_rdynamic))
       CmdArgs.push_back("-export-dynamic");
 
-    if (!Args.hasArg(options::OPT_shared) && !IsStaticPIE && !IsRepo) {
+    if (!Args.hasArg(options::OPT_shared) && !IsStaticPIE) {
       CmdArgs.push_back("-dynamic-linker");
       CmdArgs.push_back(Args.MakeArgString(Twine(D.DyldPrefix) +
                                            ToolChain.getDynamicLinker(Args)));
@@ -503,7 +499,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   CmdArgs.push_back(Output.getFilename());
 
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nostartfiles)) {
-    if (!isAndroid && !IsIAMCU && !IsRepo) {
+    if (!isAndroid && !IsIAMCU) {
       const char *crt1 = nullptr;
       if (!Args.hasArg(options::OPT_shared)) {
         if (Args.hasArg(options::OPT_pg))
@@ -521,13 +517,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("crti.o")));
     }
 
-    if (IsRepo) {
-      std::string MuslRoot = D.SysRoot.empty() ? "/usr/local/musl" : D.SysRoot;
-      CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1.t"));
-      CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1_asm.t"));
-      CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/libc_repo.a"));
-    }
-
     if (IsVE) {
       CmdArgs.push_back("-z");
       CmdArgs.push_back("max-page-size=0x4000000");
@@ -535,16 +524,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
     if (IsIAMCU)
       CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("crt0.o")));
-    else if (IsRepo &&
-             !Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib)) {
-      auto CRTPath = ToolChain.getCompilerRTPath();
-      if (!ToolChain.getVFS().exists(CRTPath))
-        CRTPath = "/usr/lib/linux";
-      CmdArgs.push_back(
-          Args.MakeArgString(CRTPath + "/clang_rt.crtbegin-x86_64.o"));
-      CmdArgs.push_back(
-          Args.MakeArgString(CRTPath + "/clang_rt.crtend-x86_64.o"));
-    } else if (HasCRTBeginEndFiles) {
+    else if (HasCRTBeginEndFiles) {
       std::string P;
       if (ToolChain.GetRuntimeLibType(Args) == ToolChain::RLT_CompilerRT &&
           !isAndroid) {
@@ -575,8 +555,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   Args.AddAllArgs(CmdArgs, options::OPT_L);
   Args.AddAllArgs(CmdArgs, options::OPT_u);
 
-  if (!IsRepo)
-    ToolChain.AddFilePathLibArgs(Args, CmdArgs);
+  ToolChain.AddFilePathLibArgs(Args, CmdArgs);
 
   if (D.isUsingLTO()) {
     assert(!Inputs.empty() && "Must have at least one input.");
@@ -636,8 +615,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
         // FIXME: Does this really make sense for all GNU toolchains?
         WantPthread = true;
 
-      if (!IsRepo)
-        AddRunTimeLibs(ToolChain, D, CmdArgs, Args);
+      AddRunTimeLibs(ToolChain, D, CmdArgs, Args);
 
       if (WantPthread && !isAndroid)
         CmdArgs.push_back("-lpthread");
@@ -645,7 +623,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       if (Args.hasArg(options::OPT_fsplit_stack))
         CmdArgs.push_back("--wrap=pthread_create");
 
-      if (!Args.hasArg(options::OPT_nolibc) && !IsRepo)
+      if (!Args.hasArg(options::OPT_nolibc))
         CmdArgs.push_back("-lc");
 
       // Add IAMCU specific libs, if needed.
@@ -654,7 +632,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
       if (IsStatic || IsStaticPIE)
         CmdArgs.push_back("--end-group");
-      else if (!IsRepo)
+      else
         AddRunTimeLibs(ToolChain, D, CmdArgs, Args);
 
       // Add IAMCU specific libs (outside the group), if needed.
@@ -665,7 +643,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       }
     }
 
-    if (!Args.hasArg(options::OPT_nostartfiles) && !IsIAMCU && !IsRepo) {
+    if (!Args.hasArg(options::OPT_nostartfiles) && !IsIAMCU) {
       if (HasCRTBeginEndFiles) {
         std::string P;
         if (ToolChain.GetRuntimeLibType(Args) == ToolChain::RLT_CompilerRT &&
@@ -687,7 +665,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
         }
         CmdArgs.push_back(Args.MakeArgString(P));
       }
-      if (!isAndroid && !IsRepo)
+      if (!isAndroid)
         CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("crtn.o")));
     }
   }

--- a/clang/lib/Driver/ToolChains/Repo.cpp
+++ b/clang/lib/Driver/ToolChains/Repo.cpp
@@ -35,8 +35,8 @@ static void constructRepoLinkArgs(Compilation &C, const JobAction &JA,
 
   std::string MuslRoot = D.SysRoot.empty() ? "/usr/local/musl" : D.SysRoot;
   if (!Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib)) {
-    CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1.t.o"));
-    CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1_asm.t.o"));
+    CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1.t"));
+    CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1_asm.t"));
   }
 
   auto CRTPath = RTC.getCompilerRTPath();
@@ -46,6 +46,9 @@ static void constructRepoLinkArgs(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(
         Args.MakeArgString(CRTPath + "/clang_rt.crtend-x86_64.o"));
   }
+
+  // Temporarily disable the code since rld doesn't support -L and -l yet.
+#if 0
 
   //----------------------------------------------------------------------------
   // Library Search Paths
@@ -80,6 +83,7 @@ static void constructRepoLinkArgs(Compilation &C, const JobAction &JA,
       RTC.AddCXXStdlibLibArgs(Args, CmdArgs);
   }
 
+#endif // 0
   return;
 }
 
@@ -101,7 +105,7 @@ void repo::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
 RepoToolChain::RepoToolChain(const Driver &D, const llvm::Triple &Triple,
                              const llvm::opt::ArgList &Args)
-    : Linux(D, Triple, Args) {
+    : ToolChain(D, Triple, Args) {
   getProgramPaths().push_back(getDriver().getInstalledDir());
   if (getDriver().getInstalledDir() != getDriver().Dir)
     getProgramPaths().push_back(getDriver().Dir);
@@ -126,6 +130,24 @@ void RepoToolChain::AddCXXStdlibLibArgs(const ArgList &Args,
 
 Tool *RepoToolChain::buildLinker() const {
   return new tools::repo::Linker(*this);
+}
+
+bool RepoToolChain::isPICDefault() const {
+  switch (getArch()) {
+  case llvm::Triple::x86_64:
+    return getTriple().isOSWindows();
+  case llvm::Triple::mips64:
+  case llvm::Triple::mips64el:
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool RepoToolChain::isPIEDefault() const { return false; }
+
+bool RepoToolChain::isPICDefaultForced() const {
+  return getArch() == llvm::Triple::x86_64 && getTriple().isOSWindows();
 }
 
 void RepoToolChain::addClangTargetOptions(const ArgList &DriverArgs,
@@ -161,15 +183,7 @@ void RepoToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
     } else {
       addSystemInclude(DriverArgs, CC1Args, "/usr/local/musl/include");
     }
-    return;
   }
-
-  Linux::AddClangSystemIncludeArgs(DriverArgs, CC1Args);
-}
-
-void RepoToolChain::addLibCxxIncludePaths(
-    const llvm::opt::ArgList &DriverArgs,
-    llvm::opt::ArgStringList &CC1Args) const {
 
   if (DriverArgs.hasArg(options::OPT_nostdinc) ||
       DriverArgs.hasArg(options::OPT_nostdlibinc) ||

--- a/clang/lib/Driver/ToolChains/Repo.cpp
+++ b/clang/lib/Driver/ToolChains/Repo.cpp
@@ -1,0 +1,251 @@
+//===--- Repo.cpp - Repo ToolChain Implementations --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Repo.h"
+#include "CommonArgs.h"
+#include "clang/Driver/Compilation.h"
+#include "clang/Driver/DriverDiagnostic.h"
+#include "llvm/Support/VirtualFileSystem.h"
+
+using namespace clang::driver;
+using namespace clang::driver::tools;
+using namespace clang::driver::toolchains;
+using namespace clang;
+using namespace llvm::opt;
+
+static void constructRepoLinkArgs(Compilation &C, const JobAction &JA,
+                                  const toolchains::RepoToolChain &RTC,
+                                  const InputInfo &Output,
+                                  const InputInfoList &Inputs,
+                                  const ArgList &Args, ArgStringList &CmdArgs,
+                                  const char *LinkingOutput) {
+
+  const Driver &D = RTC.getDriver();
+
+  //----------------------------------------------------------------------------
+  // Silence warnings for various options
+  //----------------------------------------------------------------------------
+  Args.ClaimAllArgs(options::OPT_g_Group);
+  Args.ClaimAllArgs(options::OPT_emit_llvm);
+  Args.ClaimAllArgs(options::OPT_w); // Other warning options are already
+                                     // handled somewhere else.
+
+  //----------------------------------------------------------------------------
+  //
+  //----------------------------------------------------------------------------
+  if (Args.hasArg(options::OPT_s))
+    CmdArgs.push_back("-s");
+
+  if (Args.hasArg(options::OPT_r))
+    CmdArgs.push_back("-r");
+
+  for (const auto &Opt : RTC.ExtraOpts)
+    CmdArgs.push_back(Opt.c_str());
+
+  if (Args.hasArg(options::OPT_shared))
+    CmdArgs.push_back("-shared");
+
+  if (Args.hasArg(options::OPT_static))
+    CmdArgs.push_back("-static");
+
+  if (Args.hasArg(options::OPT_pie))
+    CmdArgs.push_back("-pie");
+
+  CmdArgs.push_back("-o");
+  CmdArgs.push_back(Output.getFilename());
+
+  assert(RTC.getTriple().isMusl() &&
+         "The linker should be only run on the musl-libc environment.");
+
+  std::string MuslRoot = D.SysRoot.empty() ? "/usr/local/musl" : D.SysRoot;
+  if (!Args.hasArg(options::OPT_shared, options::OPT_nostartfiles,
+                   options::OPT_nostdlib)) {
+    CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1.t.o"));
+    CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1_asm.t.o"));
+  } else if (Args.hasArg(options::OPT_shared) &&
+             !Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib)) {
+    CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crti.t.o"));
+  }
+
+  auto CRTPath = RTC.getCompilerRTPath();
+  if (!Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib)) {
+    CmdArgs.push_back(
+        Args.MakeArgString(CRTPath + "/clang_rt.crtbegin-x86_64.o"));
+    CmdArgs.push_back(
+        Args.MakeArgString(CRTPath + "/clang_rt.crtend-x86_64.o"));
+  }
+
+  //----------------------------------------------------------------------------
+  // Library Search Paths
+  //----------------------------------------------------------------------------
+  CmdArgs.push_back(Args.MakeArgString(StringRef("-L") + MuslRoot + "/lib"));
+
+  if (RTC.getVFS().exists(CRTPath))
+    CmdArgs.push_back(Args.MakeArgString("-L" + CRTPath));
+
+  const ToolChain::path_list &LibPaths = RTC.getFilePaths();
+  for (const auto &LibPath : LibPaths)
+    CmdArgs.push_back(Args.MakeArgString(StringRef("-L") + LibPath));
+
+  //----------------------------------------------------------------------------
+  //
+  //----------------------------------------------------------------------------
+  Args.AddAllArgs(CmdArgs,
+                  {options::OPT_T_Group, options::OPT_e, options::OPT_s,
+                   options::OPT_t, options::OPT_u_Group});
+  AddLinkerInputs(RTC, Inputs, Args, CmdArgs, JA);
+
+  //----------------------------------------------------------------------------
+  // Libraries
+  //----------------------------------------------------------------------------
+  if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs)) {
+    CmdArgs.push_back("-lclang_rt.builtins-x86_64");
+    CmdArgs.push_back("-lc");
+  }
+
+  if (D.CCCIsCXX()) {
+    if (RTC.ShouldLinkCXXStdlib(Args))
+      RTC.AddCXXStdlibLibArgs(Args, CmdArgs);
+  }
+
+  return;
+}
+
+void repo::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+                                const InputInfo &Output,
+                                const InputInfoList &Inputs,
+                                const ArgList &Args,
+                                const char *LinkingOutput) const {
+  auto &RTC = static_cast<const toolchains::RepoToolChain &>(getToolChain());
+
+  ArgStringList CmdArgs;
+  constructRepoLinkArgs(C, JA, RTC, Output, Inputs, Args, CmdArgs,
+                        LinkingOutput);
+
+  const char *Exec = Args.MakeArgString(RTC.GetLinkerPath());
+  C.addCommand(std::make_unique<Command>(
+      JA, *this, ResponseFileSupport::AtFileCurCP(), Exec, CmdArgs, Inputs));
+}
+
+RepoToolChain::RepoToolChain(const Driver &D, const llvm::Triple &Triple,
+                             const llvm::opt::ArgList &Args)
+    : Linux(D, Triple, Args) {
+  getProgramPaths().push_back(getDriver().getInstalledDir());
+  if (getDriver().getInstalledDir() != getDriver().Dir)
+    getProgramPaths().push_back(getDriver().Dir);
+
+  if (!D.SysRoot.empty()) {
+    SmallString<128> P(D.SysRoot);
+    llvm::sys::path::append(P, "lib");
+    getFilePaths().push_back(std::string(P.str()));
+  }
+
+  getFilePaths().push_back(getDriver().Dir + "/../lib");
+}
+
+RepoToolChain::~RepoToolChain() {}
+
+void RepoToolChain::AddCXXStdlibLibArgs(const ArgList &Args,
+                                        ArgStringList &CmdArgs) const {
+  CXXStdlibType Type = GetCXXStdlibType(Args);
+  switch (Type) {
+  case ToolChain::CST_Libcxx:
+    CmdArgs.push_back("-lc++");
+    CmdArgs.push_back("-lc++abi");
+    CmdArgs.push_back("-lunwind");
+    break;
+
+  case ToolChain::CST_Libstdcxx:
+    CmdArgs.push_back("-lstdc++");
+    break;
+  }
+}
+
+Tool *RepoToolChain::buildLinker() const {
+  return new tools::repo::Linker(*this);
+}
+
+void RepoToolChain::addClangTargetOptions(const ArgList &DriverArgs,
+                                          ArgStringList &CC1Args,
+                                          Action::OffloadKind) const {
+
+  bool UseInitArrayDefault = getTriple().isMusl();
+
+  if (!DriverArgs.hasFlag(options::OPT_fuse_init_array,
+                          options::OPT_fno_use_init_array, UseInitArrayDefault))
+    CC1Args.push_back("-fno-use-init-array");
+}
+
+void RepoToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
+                                              ArgStringList &CC1Args) const {
+  if (DriverArgs.hasArg(options::OPT_nostdinc))
+    return;
+
+  const Driver &D = getDriver();
+
+  if (!DriverArgs.hasArg(options::OPT_nobuiltininc)) {
+    // Add the Clang builtin headers (<resource>/include).
+    SmallString<128> ResourceDirInclude(D.ResourceDir);
+    llvm::sys::path::append(ResourceDirInclude, "include");
+    addSystemInclude(DriverArgs, CC1Args, ResourceDirInclude);
+  }
+
+  if (DriverArgs.hasArg(options::OPT_nostdlibinc))
+    return;
+
+  if (!DriverArgs.hasArg(options::OPT_nobuiltininc) && getTriple().isMusl()) {
+    if (!D.SysRoot.empty()) {
+      SmallString<128> P(D.SysRoot);
+      llvm::sys::path::append(P, "include");
+      addSystemInclude(DriverArgs, CC1Args, P.str());
+    } else {
+      addSystemInclude(DriverArgs, CC1Args, "/usr/local/musl/include");
+    }
+    return;
+  }
+
+  Linux::AddClangSystemIncludeArgs(DriverArgs, CC1Args);
+}
+
+void RepoToolChain::addLibCxxIncludePaths(
+    const llvm::opt::ArgList &DriverArgs,
+    llvm::opt::ArgStringList &CC1Args) const {
+
+  if (DriverArgs.hasArg(options::OPT_nostdinc) ||
+      DriverArgs.hasArg(options::OPT_nostdlibinc) ||
+      DriverArgs.hasArg(options::OPT_nobuiltininc) ||
+      DriverArgs.hasArg(options::OPT_nostdincxx))
+    return;
+
+  // On musl-repo, libc++ is installed alongside the compiler in include/c++/v1,
+  // so get from '<install>/bin' to '<install>/include/c++/v1'.
+  llvm::SmallString<128> P = llvm::StringRef(getDriver().getInstalledDir());
+  llvm::sys::path::append(P, "..", "include", "c++", "v1");
+  addSystemInclude(DriverArgs, CC1Args, P);
+}
+
+ToolChain::CXXStdlibType
+RepoToolChain::GetCXXStdlibType(const ArgList &Args) const {
+  Arg *A = Args.getLastArg(options::OPT_stdlib_EQ);
+  if (!A) {
+    if (getTriple().isMusl())
+      return ToolChain::CST_Libcxx;
+    else
+      return ToolChain::CST_Libstdcxx;
+  }
+  StringRef Value = A->getValue();
+  if (Value != "libstdc++" && Value != "libc++")
+    getDriver().Diag(diag::err_drv_invalid_stdlib_name) << A->getAsString(Args);
+
+  if (Value == "libstdc++")
+    return ToolChain::CST_Libstdcxx;
+  else if (Value == "libc++")
+    return ToolChain::CST_Libcxx;
+  else
+    return ToolChain::CST_Libstdcxx;
+}

--- a/clang/lib/Driver/ToolChains/Repo.cpp
+++ b/clang/lib/Driver/ToolChains/Repo.cpp
@@ -33,9 +33,6 @@ static void constructRepoLinkArgs(Compilation &C, const JobAction &JA,
   CmdArgs.push_back("-o");
   CmdArgs.push_back(Output.getFilename());
 
-  assert(RTC.getTriple().isMusl() &&
-         "The linker should be only run on the musl-libc environment.");
-
   std::string MuslRoot = D.SysRoot.empty() ? "/usr/local/musl" : D.SysRoot;
   if (!Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib)) {
     CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1.t.o"));
@@ -134,11 +131,8 @@ Tool *RepoToolChain::buildLinker() const {
 void RepoToolChain::addClangTargetOptions(const ArgList &DriverArgs,
                                           ArgStringList &CC1Args,
                                           Action::OffloadKind) const {
-
-  bool UseInitArrayDefault = getTriple().isMusl();
-
   if (!DriverArgs.hasFlag(options::OPT_fuse_init_array,
-                          options::OPT_fno_use_init_array, UseInitArrayDefault))
+                          options::OPT_fno_use_init_array, true))
     CC1Args.push_back("-fno-use-init-array");
 }
 
@@ -159,7 +153,7 @@ void RepoToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
   if (DriverArgs.hasArg(options::OPT_nostdlibinc))
     return;
 
-  if (!DriverArgs.hasArg(options::OPT_nobuiltininc) && getTriple().isMusl()) {
+  if (!DriverArgs.hasArg(options::OPT_nobuiltininc)) {
     if (!D.SysRoot.empty()) {
       SmallString<128> P(D.SysRoot);
       llvm::sys::path::append(P, "include");

--- a/clang/lib/Driver/ToolChains/Repo.cpp
+++ b/clang/lib/Driver/ToolChains/Repo.cpp
@@ -28,33 +28,13 @@ static void constructRepoLinkArgs(Compilation &C, const JobAction &JA,
   const Driver &D = RTC.getDriver();
 
   //----------------------------------------------------------------------------
-  // Silence warnings for various options
-  //----------------------------------------------------------------------------
-  Args.ClaimAllArgs(options::OPT_g_Group);
-  Args.ClaimAllArgs(options::OPT_emit_llvm);
-  Args.ClaimAllArgs(options::OPT_w); // Other warning options are already
-                                     // handled somewhere else.
-
-  //----------------------------------------------------------------------------
   //
   //----------------------------------------------------------------------------
-  if (Args.hasArg(options::OPT_s))
-    CmdArgs.push_back("-s");
-
-  if (Args.hasArg(options::OPT_r))
-    CmdArgs.push_back("-r");
-
-  for (const auto &Opt : RTC.ExtraOpts)
-    CmdArgs.push_back(Opt.c_str());
-
   if (Args.hasArg(options::OPT_shared))
     CmdArgs.push_back("-shared");
 
   if (Args.hasArg(options::OPT_static))
     CmdArgs.push_back("-static");
-
-  if (Args.hasArg(options::OPT_pie))
-    CmdArgs.push_back("-pie");
 
   CmdArgs.push_back("-o");
   CmdArgs.push_back(Output.getFilename());
@@ -152,18 +132,9 @@ RepoToolChain::~RepoToolChain() {}
 
 void RepoToolChain::AddCXXStdlibLibArgs(const ArgList &Args,
                                         ArgStringList &CmdArgs) const {
-  CXXStdlibType Type = GetCXXStdlibType(Args);
-  switch (Type) {
-  case ToolChain::CST_Libcxx:
-    CmdArgs.push_back("-lc++");
-    CmdArgs.push_back("-lc++abi");
-    CmdArgs.push_back("-lunwind");
-    break;
-
-  case ToolChain::CST_Libstdcxx:
-    CmdArgs.push_back("-lstdc++");
-    break;
-  }
+  CmdArgs.push_back("-lc++");
+  CmdArgs.push_back("-lc++abi");
+  CmdArgs.push_back("-lunwind");
 }
 
 Tool *RepoToolChain::buildLinker() const {

--- a/clang/lib/Driver/ToolChains/Repo.cpp
+++ b/clang/lib/Driver/ToolChains/Repo.cpp
@@ -104,9 +104,9 @@ void repo::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 RepoToolChain::RepoToolChain(const Driver &D, const llvm::Triple &Triple,
                              const llvm::opt::ArgList &Args)
     : ToolChain(D, Triple, Args) {
-  getProgramPaths().push_back(getDriver().getInstalledDir());
-  if (getDriver().getInstalledDir() != getDriver().Dir)
-    getProgramPaths().push_back(getDriver().Dir);
+  getProgramPaths().push_back(D.getInstalledDir());
+  if (D.getInstalledDir() != D.Dir)
+    getProgramPaths().push_back(D.Dir);
 
   if (!D.SysRoot.empty()) {
     SmallString<128> P(D.SysRoot);
@@ -114,7 +114,7 @@ RepoToolChain::RepoToolChain(const Driver &D, const llvm::Triple &Triple,
     getFilePaths().push_back(std::string(P.str()));
   }
 
-  getFilePaths().push_back(getDriver().Dir + "/../lib");
+  getFilePaths().push_back(D.Dir + "/../lib");
 }
 
 RepoToolChain::~RepoToolChain() {}

--- a/clang/lib/Driver/ToolChains/Repo.cpp
+++ b/clang/lib/Driver/ToolChains/Repo.cpp
@@ -30,12 +30,6 @@ static void constructRepoLinkArgs(Compilation &C, const JobAction &JA,
   //----------------------------------------------------------------------------
   //
   //----------------------------------------------------------------------------
-  if (Args.hasArg(options::OPT_shared))
-    CmdArgs.push_back("-shared");
-
-  if (Args.hasArg(options::OPT_static))
-    CmdArgs.push_back("-static");
-
   CmdArgs.push_back("-o");
   CmdArgs.push_back(Output.getFilename());
 
@@ -43,13 +37,9 @@ static void constructRepoLinkArgs(Compilation &C, const JobAction &JA,
          "The linker should be only run on the musl-libc environment.");
 
   std::string MuslRoot = D.SysRoot.empty() ? "/usr/local/musl" : D.SysRoot;
-  if (!Args.hasArg(options::OPT_shared, options::OPT_nostartfiles,
-                   options::OPT_nostdlib)) {
+  if (!Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib)) {
     CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1.t.o"));
     CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1_asm.t.o"));
-  } else if (Args.hasArg(options::OPT_shared) &&
-             !Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib)) {
-    CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crti.t.o"));
   }
 
   auto CRTPath = RTC.getCompilerRTPath();

--- a/clang/lib/Driver/ToolChains/Repo.cpp
+++ b/clang/lib/Driver/ToolChains/Repo.cpp
@@ -37,18 +37,18 @@ static void constructRepoLinkArgs(Compilation &C, const JobAction &JA,
   if (!Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib)) {
     CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1.t"));
     CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/crt1_asm.t"));
+    CmdArgs.push_back(Args.MakeArgString(MuslRoot + "/lib/libc_repo.a"));
   }
 
   auto CRTPath = RTC.getCompilerRTPath();
+  if (!RTC.getVFS().exists(CRTPath)) // Build compiler-rt as stand-alone
+    CRTPath = "/usr/lib/linux";
   if (!Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib)) {
     CmdArgs.push_back(
         Args.MakeArgString(CRTPath + "/clang_rt.crtbegin-x86_64.o"));
     CmdArgs.push_back(
         Args.MakeArgString(CRTPath + "/clang_rt.crtend-x86_64.o"));
   }
-
-  // Temporarily disable the code since rld doesn't support -L and -l yet.
-#if 0
 
   //----------------------------------------------------------------------------
   // Library Search Paths
@@ -75,7 +75,6 @@ static void constructRepoLinkArgs(Compilation &C, const JobAction &JA,
   //----------------------------------------------------------------------------
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs)) {
     CmdArgs.push_back("-lclang_rt.builtins-x86_64");
-    CmdArgs.push_back("-lc");
   }
 
   if (D.CCCIsCXX()) {
@@ -83,7 +82,6 @@ static void constructRepoLinkArgs(Compilation &C, const JobAction &JA,
       RTC.AddCXXStdlibLibArgs(Args, CmdArgs);
   }
 
-#endif // 0
   return;
 }
 

--- a/clang/lib/Driver/ToolChains/Repo.h
+++ b/clang/lib/Driver/ToolChains/Repo.h
@@ -1,0 +1,75 @@
+//===--- Repo.h - Repo ToolChain Implementations ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_REPO_H
+#define LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_REPO_H
+
+#include "Linux.h"
+#include "clang/Driver/Tool.h"
+#include "clang/Driver/ToolChain.h"
+
+namespace clang {
+namespace driver {
+namespace tools {
+namespace repo {
+
+class LLVM_LIBRARY_VISIBILITY Linker : public Tool {
+public:
+  Linker(const ToolChain &TC) : Tool("repo::Linker", "rld", TC) {}
+
+  bool hasIntegratedCPP() const override { return false; }
+  bool isLinkJob() const override { return true; }
+
+  void ConstructJob(Compilation &C, const JobAction &JA,
+                    const InputInfo &Output, const InputInfoList &Inputs,
+                    const llvm::opt::ArgList &TCArgs,
+                    const char *LinkingOutput) const override;
+};
+} // namespace repo
+} // namespace tools
+
+namespace toolchains {
+
+class LLVM_LIBRARY_VISIBILITY RepoToolChain : public Linux {
+protected:
+  Tool *buildLinker() const override;
+
+public:
+  RepoToolChain(const Driver &D, const llvm::Triple &Triple,
+                const llvm::opt::ArgList &Args);
+  ~RepoToolChain() override;
+
+  void
+  addClangTargetOptions(const llvm::opt::ArgList &DriverArgs,
+                        llvm::opt::ArgStringList &CC1Args,
+                        Action::OffloadKind DeviceOffloadKind) const override;
+  void
+  AddClangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
+                            llvm::opt::ArgStringList &CC1Args) const override;
+
+  void addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+                             llvm::opt::ArgStringList &CC1Args) const override;
+
+  const char *getDefaultLinker() const override {
+    return getTriple().isMusl() ? "rld"
+                                : "ld.lld";
+  }
+
+  CXXStdlibType GetCXXStdlibType(const llvm::opt::ArgList &Args) const override;
+
+  void AddCXXStdlibLibArgs(const llvm::opt::ArgList &Args,
+                           llvm::opt::ArgStringList &CmdArgs) const override;
+
+  bool IsIntegratedAssemblerDefault() const override { return true; }
+};
+
+} // end namespace toolchains
+} // end namespace driver
+} // end namespace clang
+
+#endif // LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_REPO_H

--- a/clang/lib/Driver/ToolChains/Repo.h
+++ b/clang/lib/Driver/ToolChains/Repo.h
@@ -35,7 +35,9 @@ public:
 
 namespace toolchains {
 
-class LLVM_LIBRARY_VISIBILITY RepoToolChain : public Linux {
+class LLVM_LIBRARY_VISIBILITY RepoToolChain : public ToolChain {
+  friend class Linux;
+
 protected:
   Tool *buildLinker() const override;
 
@@ -44,6 +46,10 @@ public:
                 const llvm::opt::ArgList &Args);
   ~RepoToolChain() override;
 
+  bool isPICDefault() const override;
+  bool isPIEDefault() const override;
+  bool isPICDefaultForced() const override;
+
   void
   addClangTargetOptions(const llvm::opt::ArgList &DriverArgs,
                         llvm::opt::ArgStringList &CC1Args,
@@ -51,9 +57,6 @@ public:
   void
   AddClangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
                             llvm::opt::ArgStringList &CC1Args) const override;
-
-  void addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
-                             llvm::opt::ArgStringList &CC1Args) const override;
 
   const char *getDefaultLinker() const override { return "rld"; }
 

--- a/clang/lib/Driver/ToolChains/Repo.h
+++ b/clang/lib/Driver/ToolChains/Repo.h
@@ -18,6 +18,7 @@ namespace driver {
 namespace tools {
 namespace repo {
 
+/// A class to directly call repo linker when targeting on *-repo.
 class LLVM_LIBRARY_VISIBILITY Linker : public Tool {
 public:
   Linker(const ToolChain &TC) : Tool("repo::Linker", "rld", TC) {}
@@ -35,6 +36,14 @@ public:
 
 namespace toolchains {
 
+/// RepoMuslToolChain - A tool chain using the repo tools and repo-based
+/// musl-libc and llvm libc++ libraries to perform compilation and linking
+/// commands. Currently does not support repo-based glibc library but
+/// compilation is fine.
+/// Since the *-musl-* toolchain doesn't support in the upstream LLVM, we need
+/// to add this class when targetting on repo and using musl libc linrary. We
+/// could add the musl toolchain support (like gnu toolchain).
+/// TODO: support musl toolcahin in upstream LLVM.
 class LLVM_LIBRARY_VISIBILITY RepoMuslToolChain : public ToolChain {
   friend class Linux;
 

--- a/clang/lib/Driver/ToolChains/Repo.h
+++ b/clang/lib/Driver/ToolChains/Repo.h
@@ -35,16 +35,16 @@ public:
 
 namespace toolchains {
 
-class LLVM_LIBRARY_VISIBILITY RepoToolChain : public ToolChain {
+class LLVM_LIBRARY_VISIBILITY RepoMuslToolChain : public ToolChain {
   friend class Linux;
 
 protected:
   Tool *buildLinker() const override;
 
 public:
-  RepoToolChain(const Driver &D, const llvm::Triple &Triple,
-                const llvm::opt::ArgList &Args);
-  ~RepoToolChain() override;
+  RepoMuslToolChain(const Driver &D, const llvm::Triple &Triple,
+                    const llvm::opt::ArgList &Args);
+  ~RepoMuslToolChain() override;
 
   bool isPICDefault() const override;
   bool isPIEDefault() const override;

--- a/clang/lib/Driver/ToolChains/Repo.h
+++ b/clang/lib/Driver/ToolChains/Repo.h
@@ -40,10 +40,9 @@ namespace toolchains {
 /// musl-libc and llvm libc++ libraries to perform compilation and linking
 /// commands. Currently does not support repo-based glibc library but
 /// compilation is fine.
-/// Since the *-musl-* toolchain doesn't support in the upstream LLVM, we need
-/// to add this class when targetting on repo and using musl libc linrary. We
+/// Since the *-musl-* toolchain isn't supported by upstream LLVM, we need to
+/// add this class when targeting the repo and using the musl libc library. We
 /// could add the musl toolchain support (like gnu toolchain).
-/// TODO: support musl toolcahin in upstream LLVM.
 class LLVM_LIBRARY_VISIBILITY RepoMuslToolChain : public ToolChain {
   friend class Linux;
 

--- a/clang/lib/Driver/ToolChains/Repo.h
+++ b/clang/lib/Driver/ToolChains/Repo.h
@@ -55,10 +55,7 @@ public:
   void addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
                              llvm::opt::ArgStringList &CC1Args) const override;
 
-  const char *getDefaultLinker() const override {
-    return getTriple().isMusl() ? "rld"
-                                : "ld.lld";
-  }
+  const char *getDefaultLinker() const override { return "rld"; }
 
   CXXStdlibType GetCXXStdlibType(const llvm::opt::ArgList &Args) const override;
 

--- a/clang/test/Driver/repo-toolchain-linux-musl.c
+++ b/clang/test/Driver/repo-toolchain-linux-musl.c
@@ -7,6 +7,19 @@
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -stdlib=libc++ \
+// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-repo -stdlib=libc++ \
+// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX %s
+
 // CHECK-X86-64-LIBCXX: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-X86-64-LIBCXX: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
 // CHECK-X86-64-LIBCXX: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
@@ -17,6 +30,20 @@
 // Passing --musl -stdlib=libc++ --sysroot
 // -----------------------------------------------------------------------------
 // RUN: %clangxx -### -target x86_64-pc-linux-musl-repo -stdlib=libc++ \
+// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:     -resource-dir=%S/Inputs/resource_dir \
+// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:     %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-SYSROOT %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -stdlib=libc++ \
+// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:     -resource-dir=%S/Inputs/resource_dir \
+// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:     %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-SYSROOT %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-repo -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
 // RUN:     -resource-dir=%S/Inputs/resource_dir \
 // RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
@@ -38,6 +65,21 @@
 // RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:     %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-NOSTDINC-SYSROOT %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -nostdinc \
+// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:     -resource-dir=%S/Inputs/resource_dir \
+// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:     %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOSTDINC-SYSROOT %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-repo -nostdinc \
+// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:     -resource-dir=%S/Inputs/resource_dir \
+// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:     %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOSTDINC-SYSROOT %s
+
 // CHECK-NOSTDINC-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-NOSTDINC-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
 // CHECK-NOSTDINC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
@@ -54,6 +96,21 @@
 // RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:     %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-NOBUILTININC-SYSROOT %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -nobuiltininc \
+// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:     -resource-dir=%S/Inputs/resource_dir \
+// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:     %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOBUILTININC-SYSROOT %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-repo -nobuiltininc \
+// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:     -resource-dir=%S/Inputs/resource_dir \
+// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:     %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOBUILTININC-SYSROOT %s
+
 // CHECK-NOBUILTININC: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-NOBUILTININC: "-isysroot" "[[SYSROOT:[^"]+]]"
 // CHECK-NOBUILTININC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
@@ -70,6 +127,21 @@
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-NOSTDLIBINC-SYSROOT %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -nostdlibinc \
+// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOSTDLIBINC-SYSROOT %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-repo -nostdlibinc \
+// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOSTDLIBINC-SYSROOT %s
+
 // CHECK-NOSTDLIBINC-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-NOSTDLIBINC-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
 // CHECK-NOSTDLIBINC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
@@ -82,6 +154,13 @@
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK000 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-gnu-repo %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK000 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-repo %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK000 %s
+
 // CHECK000-NOT:  "/usr/local/musl/lib/crti.t.o"
 // CHECK000:      "/usr/local/musl/lib/crt1.t.o"
 // CHECK000:      "/usr/local/musl/lib/crt1_asm.t.o"
@@ -98,6 +177,19 @@
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK001 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-gnu-repo \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK001 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-repo \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK001 %s
+
 // CHECK001:      "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK001:      "-isysroot" "[[SYSROOT:[^"]+]]"
 // CHECK001-NOT:  "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t.o"
@@ -114,6 +206,15 @@
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo -nostdlib %s 2>&1 \
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   | FileCheck -check-prefix=CHECK002 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-gnu-repo -nostdlib %s 2>&1 \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   | FileCheck -check-prefix=CHECK002 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-repo -nostdlib %s 2>&1 \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   | FileCheck -check-prefix=CHECK002 %s
+
 // CHECK002:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK002-NOT:   "/usr/local/musl/lib/crti.t.o"
 // CHECK002-NOT:   "/usr/local/musl/lib/crt1.t.o"
@@ -133,6 +234,19 @@
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK003 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-gnu-repo -nostartfiles \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK003 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-repo -nostartfiles \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK003 %s
+
 // CHECK003:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o
 // CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t.o
@@ -150,6 +264,19 @@
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK004 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-gnu-repo -nodefaultlibs \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK004 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-repo -nodefaultlibs \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK004 %s
+
 // CHECK004:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK004:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t.o
 // CHECK004:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o
@@ -164,6 +291,13 @@
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK005 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-gnu-repo %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK005 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-repo %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK005 %s
+
 // CHECK005-NOT:          -fno-use-init-array
 
 // -----------------------------------------------------------------------------
@@ -175,6 +309,19 @@
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
 // RUN:   %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK006 %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK006 %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-repo \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK006 %s
+
 // CHECK006:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK006:  "-L{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}lib"
 // CHECK006:  "-L[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux"

--- a/clang/test/Driver/repo-toolchain-linux-musl.c
+++ b/clang/test/Driver/repo-toolchain-linux-musl.c
@@ -160,12 +160,6 @@
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK005 %s
 
-// RUN: %clang -### -target x86_64-pc-linux-gnu-repo %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK005 %s
-
-// RUN: %clang -### -target x86_64-pc-linux-repo %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK005 %s
-
 // CHECK005-NOT:          -fno-use-init-array
 
 // -----------------------------------------------------------------------------

--- a/clang/test/Driver/repo-toolchain-linux-musl.c
+++ b/clang/test/Driver/repo-toolchain-linux-musl.c
@@ -1,41 +1,61 @@
 // -----------------------------------------------------------------------------
 // Checking the header search
-// Passing --musl -stdlib=libc++
+// Passing -musl -stdlib=libc++
 // -----------------------------------------------------------------------------
-// RUN: %clangxx -### -target x86_64-pc-linux-musl-repo -stdlib=libc++ \
+// RUN: %clangxx -### -no-canonical-prefixes -target x86_64-pc-linux-musl-repo -stdlib=libc++ \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX %s
+// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-MUSL %s
 
-// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -stdlib=libc++ \
-// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX %s
-
-// RUN: %clangxx -### -target x86_64-pc-linux-repo -stdlib=libc++ \
-// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX %s
-
-// CHECK-X86-64-LIBCXX: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK-X86-64-LIBCXX: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-X86-64-LIBCXX: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
-// CHECK-X86-64-LIBCXX: "-internal-isystem" "{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}include"
+// CHECK-X86-64-LIBCXX-MUSL: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
+// CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}include"
+// CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
 
 // -----------------------------------------------------------------------------
 // Checking the header search
-// Passing --musl -stdlib=libc++ --sysroot
+// Passing -gnu -stdlib=libc++
+// -----------------------------------------------------------------------------
+
+// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -stdlib=libc++ \
+// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-GNU %s
+
+// RUN: %clangxx -### -target x86_64-pc-linux-repo -stdlib=libc++ \
+// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-GNU %s
+
+// CHECK-X86-64-LIBCXX-GNU: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK-X86-64-LIBCXX-GNU: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
+// CHECK-X86-64-LIBCXX-GNU: "-internal-externc-isystem" "/usr/include"
+// CHECK-X86-64-LIBCXX-GNU-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+
+// -----------------------------------------------------------------------------
+// Checking the header search
+// Passing -musl -stdlib=libc++ --sysroot
 // -----------------------------------------------------------------------------
 // RUN: %clangxx -### -target x86_64-pc-linux-musl-repo -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
 // RUN:     -resource-dir=%S/Inputs/resource_dir \
 // RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:     %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-SYSROOT %s
+// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-SYSROOT-MUSL %s
 
+// CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-isysroot" "[[SYSROOT:[^"]+]]"
+// CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
+// CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
+// CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+
+// -----------------------------------------------------------------------------
+// Checking the header search
+// Passing -gnu -stdlib=libc++ --sysroot
+// -----------------------------------------------------------------------------
 // RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
 // RUN:     -resource-dir=%S/Inputs/resource_dir \
@@ -49,11 +69,12 @@
 // RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:     %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-SYSROOT %s
+
 // CHECK-X86-64-LIBCXX-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-X86-64-LIBCXX-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
-// CHECK-X86-64-LIBCXX-SYSROOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-X86-64-LIBCXX-SYSROOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}usr{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
 // CHECK-X86-64-LIBCXX-SYSROOT: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
-// CHECK-X86-64-LIBCXX-SYSROOT: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
+// CHECK-X86-64-LIBCXX-SYSROOT: "-internal-externc-isystem" "[[SYSROOT]]{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
 // Checking the header search
@@ -161,12 +182,13 @@
 // RUN: %clang -### -target x86_64-pc-linux-repo %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK000 %s
 
-// CHECK000-NOT:  "/usr/local/musl/lib/crti.t.o"
-// CHECK000:      "/usr/local/musl/lib/crt1.t.o"
-// CHECK000:      "/usr/local/musl/lib/crt1_asm.t.o"
+// CHECK000:      "{{.*}}rld"
+// CHECK000-NOT:  "/usr/local/musl/lib/crti.t"
+// CHECK000:      "/usr/local/musl/lib/crt1.t"
+// CHECK000:      "/usr/local/musl/lib/crt1_asm.t"
 // CHECK000:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
 // CHECK000:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK000:      "-lclang_rt.builtins-x86_64" "-lc"
+// CHECK000-NOT:  "-lclang_rt.builtins-x86_64" "-lc"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -192,12 +214,12 @@
 
 // CHECK001:      "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK001:      "-isysroot" "[[SYSROOT:[^"]+]]"
-// CHECK001-NOT:  "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t.o"
-// CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1.t.o"
-// CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o"
+// CHECK001-NOT:  "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t"
+// CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1.t"
+// CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t"
 // CHECK001:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
 // CHECK001:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK001:      "-lclang_rt.builtins-x86_64" "-lc"
+// CHECK001-NOT:  "-lclang_rt.builtins-x86_64" "-lc"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -216,9 +238,9 @@
 // RUN:   | FileCheck -check-prefix=CHECK002 %s
 
 // CHECK002:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK002-NOT:   "/usr/local/musl/lib/crti.t.o"
-// CHECK002-NOT:   "/usr/local/musl/lib/crt1.t.o"
-// CHECK002-NOT:   "/usr/local/musl/lib/crt1_asm.t.o"
+// CHECK002-NOT:   "/usr/local/musl/lib/crti.t"
+// CHECK002-NOT:   "/usr/local/musl/lib/crt1.t"
+// CHECK002-NOT:   "/usr/local/musl/lib/crt1_asm.t"
 // CHECK002-NOT:   "-lclang_rt.builtins-x86_64"
 // CHECK002-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
 // CHECK002-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
@@ -248,12 +270,12 @@
 // RUN:   | FileCheck -check-prefix=CHECK003 %s
 
 // CHECK003:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o
-// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t.o
-// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}Scrt1.o
+// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t
+// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t
+// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}Scrt1
 // CHECK003-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
 // CHECK003-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK003:       "-lclang_rt.builtins-x86_64" "-lc"
+// CHECK003-NOT:   "-lclang_rt.builtins-x86_64" "-lc"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -278,8 +300,8 @@
 // RUN:   | FileCheck -check-prefix=CHECK004 %s
 
 // CHECK004:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK004:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t.o
-// CHECK004:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o
+// CHECK004:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t
+// CHECK004:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t
 // CHECK004:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
 // CHECK004:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
 // CHECK004-NOT:   -lclang_rt.builtins-x86_64
@@ -323,7 +345,22 @@
 // RUN:   | FileCheck -check-prefix=CHECK006 %s
 
 // CHECK006:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK006:  "-L{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}lib"
-// CHECK006:  "-L[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux"
-// CHECK006:  "-L{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}lib"
-// CHECK006:  "-lc++" "-lc++abi" "-lunwind"
+// CHECK006-NOT:  "-L{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}lib"
+// CHECK006-NOT:  "-L[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux"
+// CHECK006-NOT:  "-L{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}lib"
+// CHECK006-NOT:  "-lc++" "-lc++abi" "-lunwind"
+
+// -----------------------------------------------------------------------------
+// Checking the invoked linker for elf.
+// Passing -musl, -gnu and linux
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK007 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-gnu %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK007 %s
+
+// RUN: %clang -### -target x86_64-pc-linux %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK007 %s
+
+// CHECK007:      "{{.*}}ld"

--- a/clang/test/Driver/repo-toolchain-linux-musl.c
+++ b/clang/test/Driver/repo-toolchain-linux-musl.c
@@ -1,0 +1,244 @@
+// -----------------------------------------------------------------------------
+// Checking the header search
+// Passing --musl -stdlib=libc++
+// -----------------------------------------------------------------------------
+// RUN: %clangxx -### -target x86_64-pc-linux-musl-repo -stdlib=libc++ \
+// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX %s
+// CHECK-X86-64-LIBCXX: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK-X86-64-LIBCXX: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-X86-64-LIBCXX: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
+// CHECK-X86-64-LIBCXX: "-internal-isystem" "{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}include"
+
+// -----------------------------------------------------------------------------
+// Checking the header search
+// Passing --musl -stdlib=libc++ --sysroot
+// -----------------------------------------------------------------------------
+// RUN: %clangxx -### -target x86_64-pc-linux-musl-repo -stdlib=libc++ \
+// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:     -resource-dir=%S/Inputs/resource_dir \
+// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:     %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-SYSROOT %s
+// CHECK-X86-64-LIBCXX-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK-X86-64-LIBCXX-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
+// CHECK-X86-64-LIBCXX-SYSROOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-X86-64-LIBCXX-SYSROOT: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
+// CHECK-X86-64-LIBCXX-SYSROOT: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
+
+// -----------------------------------------------------------------------------
+// Checking the header search
+// Passing --musl -nostdinc --sysroot
+// -----------------------------------------------------------------------------
+// RUN: %clangxx -### -target x86_64-pc-linux-musl-repo -nostdinc \
+// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:     -resource-dir=%S/Inputs/resource_dir \
+// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:     %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOSTDINC-SYSROOT %s
+// CHECK-NOSTDINC-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK-NOSTDINC-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
+// CHECK-NOSTDINC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-NOSTDINC-SYSROOT-NOT: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
+// CHECK-NOSTDINC-SYSROOT-NOT: "-internal-isystem" "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
+
+// -----------------------------------------------------------------------------
+// Checking the header search
+// Passing --musl -nobuiltininc --sysroot
+// -----------------------------------------------------------------------------
+// RUN: %clangxx -### -target x86_64-pc-linux-musl-repo -nobuiltininc \
+// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:     -resource-dir=%S/Inputs/resource_dir \
+// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:     %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOBUILTININC-SYSROOT %s
+// CHECK-NOBUILTININC: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK-NOBUILTININC: "-isysroot" "[[SYSROOT:[^"]+]]"
+// CHECK-NOBUILTININC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-NOBUILTININC-SYSROOT-NOT: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
+// CHECK-NOBUILTININC-SYSROOT-NOT: "-internal-isystem" "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
+
+// -----------------------------------------------------------------------------
+// Checking the header search
+// Passing --musl -nostdlibinc --sysroot
+// -----------------------------------------------------------------------------
+// RUN: %clangxx -### -target x86_64-pc-linux-musl-repo -nostdlibinc \
+// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOSTDLIBINC-SYSROOT %s
+// CHECK-NOSTDLIBINC-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK-NOSTDLIBINC-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
+// CHECK-NOSTDLIBINC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-NOSTDLIBINC-SYSROOT: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
+// CHECK-NOSTDLIBINC-SYSROOT-NOT: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
+
+// -----------------------------------------------------------------------------
+// Checking the linked objects and libraries
+// Passing --musl
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl-repo %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK000 %s
+// CHECK000-NOT:  "/usr/local/musl/lib/crti.t.o"
+// CHECK000:      "/usr/local/musl/lib/crt1.t.o"
+// CHECK000:      "/usr/local/musl/lib/crt1_asm.t.o"
+// CHECK000:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK000:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK000:      "-lclang_rt.builtins-x86_64" "-lc"
+
+// -----------------------------------------------------------------------------
+// Checking the linked objects and libraries
+// Passing --musl -static
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl-repo -static %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK001 %s
+// CHECK001-NOT:  "/usr/local/musl/lib/crti.t.o"
+// CHECK001:      "/usr/local/musl/lib/crt1.t.o"
+// CHECK001:      "/usr/local/musl/lib/crt1_asm.t.o"
+// CHECK001:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK001:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK001:      "-lclang_rt.builtins-x86_64" "-lc"
+
+// -----------------------------------------------------------------------------
+// Checking the linked objects and libraries
+// Passing --musl -shared
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl-repo -shared %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK002 %s
+// CHECK002-NOT:   "/usr/local/musl/lib/crt1.t.o"
+// CHECK002-NOT:   "/usr/local/musl/lib/crt1_asm.t.o"
+// CHECK002:       "/usr/local/musl/lib/crti.t.o"
+// CHECK002:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK002:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK002:       "-lclang_rt.builtins-x86_64" "-lc"
+
+// -----------------------------------------------------------------------------
+// Checking the linked objects and libraries
+// Passing --musl --sysroot -resource-dir
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl-repo \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK003 %s
+// CHECK003:      "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK003:      "-isysroot" "[[SYSROOT:[^"]+]]"
+// CHECK003-NOT:  "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t.o"
+// CHECK003:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1.t.o"
+// CHECK003:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o"
+// CHECK003:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK003:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK003:      "-lclang_rt.builtins-x86_64" "-lc"
+
+// -----------------------------------------------------------------------------
+// Checking the linked objects and libraries
+// Passing --musl -static --sysroot
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl-repo -static \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK004 %s
+// CHECK004:      "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK004:      "-isysroot" "[[SYSROOT:[^"]+]]"
+// CHECK004-NOT:  "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t.o"
+// CHECK004:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1.t.o"
+// CHECK004:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o"
+// CHECK004:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK004:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK004:      "-lclang_rt.builtins-x86_64" "-lc"
+
+// -----------------------------------------------------------------------------
+// Checking the linked objects and libraries
+// Passing --musl -shared --sysroot
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl-repo -shared \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK005 %s
+// CHECK005:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK005:       "-isysroot" "[[SYSROOT:[^"]+]]"
+// CHECK005-NOT:   "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1.t.o"
+// CHECK005-NOT:   "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o"
+// CHECK005:       "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t.o"
+// CHECK005:       "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK005:       "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK005:       "-lclang_rt.builtins-x86_64" "-lc"
+
+// -----------------------------------------------------------------------------
+// Checking the linked objects and libraries
+// Passing --musl -nostdlib
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl-repo -nostdlib %s 2>&1 \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   | FileCheck -check-prefix=CHECK006 %s
+// CHECK006:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK006-NOT:   "/usr/local/musl/lib/crti.t.o"
+// CHECK006-NOT:   "/usr/local/musl/lib/crt1.t.o"
+// CHECK006-NOT:   "/usr/local/musl/lib/crt1_asm.t.o"
+// CHECK006-NOT:   "-lclang_rt.builtins-x86_64"
+// CHECK006-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK006-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK006-NOT:   "-lclang_rt.builtins-x86_64"
+// CHECK006-NOT:   "-lc"
+
+// -----------------------------------------------------------------------------
+// Checking the linked objects and libraries
+// Passing --musl -nostartfiles
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl-repo -nostartfiles \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK007 %s
+// CHECK007:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK007-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o
+// CHECK007-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t.o
+// CHECK007-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}Scrt1.o
+// CHECK007-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK007-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK007:       "-lclang_rt.builtins-x86_64" "-lc"
+
+// -----------------------------------------------------------------------------
+// Checking the linked objects and libraries
+// Passing --musl -nodefaultlibs
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl-repo -nodefaultlibs \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK008 %s
+// CHECK008:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK008:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t.o
+// CHECK008:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o
+// CHECK008:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK008:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK008-NOT:   -lclang_rt.builtins-x86_64
+// CHECK008-NOT:   -lc
+
+// -----------------------------------------------------------------------------
+// Checking the linked objects and libraries
+// Not Passing -fno-use-init-array when musl is selected
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl-repo %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK009 %s
+// CHECK009-NOT:          -fno-use-init-array
+
+// -----------------------------------------------------------------------------
+// Checking the linked objects and libraries
+// c++ when musl is selected
+// -----------------------------------------------------------------------------
+// RUN: %clangxx -### -target x86_64-pc-linux-musl-repo \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK010 %s
+// CHECK010:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK010:  "-L{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}lib"
+// CHECK010:  "-L[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux"
+// CHECK010:  "-L{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}lib"
+// CHECK010:  "-lc++" "-lc++abi" "-lunwind"

--- a/clang/test/Driver/repo-toolchain-linux-musl.c
+++ b/clang/test/Driver/repo-toolchain-linux-musl.c
@@ -78,8 +78,8 @@
 // CHECK000:      "/usr/local/musl/lib/crt1.t"
 // CHECK000:      "/usr/local/musl/lib/crt1_asm.t"
 // CHECK000:      "/usr/local/musl/lib/libc_repo.a"
-// CHECK000:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK000:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK000:      "{{/|\\\\}}usr{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK000:      "{{/|\\\\}}usr{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
 // CHECK000:      "-lclang_rt.builtins-x86_64"
 
 // -----------------------------------------------------------------------------
@@ -87,20 +87,38 @@
 // Passing --musl --sysroot
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK001 %s
 
-// CHECK001:      "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK001:      "-isysroot" "[[SYSROOT:[^"]+]]"
 // CHECK001-NOT:  "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t"
 // CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1.t"
 // CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t"
 // CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}libc_repo.a"
-// CHECK001:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK001:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
 // CHECK001:      "-lclang_rt.builtins-x86_64"
+
+// -----------------------------------------------------------------------------
+// Checking the linked objects and libraries
+// Passing --musl -resource-dir --sysroot
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl-repo \
+// RUN:   -resource-dir=%S/Inputs/resource_dir \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
+// RUN:   %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK002 %s
+
+// CHECK002:      "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK002:      "-isysroot" "[[SYSROOT:[^"]+]]"
+// CHECK002-NOT:  "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t"
+// CHECK002:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1.t"
+// CHECK002:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t"
+// CHECK002:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}libc_repo.a"
+// CHECK002:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK002:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK002:      "-lclang_rt.builtins-x86_64"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -108,15 +126,15 @@
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo -nostdlib %s 2>&1 \
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   | FileCheck -check-prefix=CHECK002 %s
+// RUN:   | FileCheck -check-prefix=CHECK003 %s
 
-// CHECK002:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK002-NOT:   "/usr/local/musl/lib/crt1.t"
-// CHECK002-NOT:   "/usr/local/musl/lib/crt1_asm.t"
-// CHECK002-NOT:   "/usr/local/musl/lib/libc_repo.a"
-// CHECK002-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK002-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK002-NOT:   "-lclang_rt.builtins-x86_64"
+// CHECK003:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK003-NOT:   "/usr/local/musl/lib/crt1.t"
+// CHECK003-NOT:   "/usr/local/musl/lib/crt1_asm.t"
+// CHECK003-NOT:   "/usr/local/musl/lib/libc_repo.a"
+// CHECK003-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK003-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK003-NOT:   "-lclang_rt.builtins-x86_64"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -126,15 +144,15 @@
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK003 %s
+// RUN:   | FileCheck -check-prefix=CHECK004 %s
 
-// CHECK003:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t
-// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t
-// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}libc_repo.a"
-// CHECK003-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK003-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK003:   "-lclang_rt.builtins-x86_64"
+// CHECK004:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK004-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t
+// CHECK004-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t
+// CHECK004-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}libc_repo.a"
+// CHECK004-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK004-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK004:   "-lclang_rt.builtins-x86_64"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -144,23 +162,23 @@
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK004 %s
+// RUN:   | FileCheck -check-prefix=CHECK005 %s
 
-// CHECK004:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK004:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t
-// CHECK004:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t
-// CHECK004:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK004:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK004-NOT:   -lclang_rt.builtins-x86_64
+// CHECK005:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK005:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t
+// CHECK005:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t
+// CHECK005:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK005:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK005-NOT:   -lclang_rt.builtins-x86_64
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
 // Not Passing -fno-use-init-array when musl is selected
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK005 %s
+// RUN:   | FileCheck -check-prefix=CHECK006 %s
 
-// CHECK005-NOT:          -fno-use-init-array
+// CHECK006-NOT:          -fno-use-init-array
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -170,40 +188,40 @@
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
 // RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK006 %s
+// RUN:   | FileCheck -check-prefix=CHECK007 %s
 
-// CHECK006:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK006:  "-L{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}lib"
-// CHECK006:  "-L[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux"
-// CHECK006:  "-L{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}lib"
-// CHECK006:  "-lc++" "-lc++abi"
+// CHECK007:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK007:  "-L{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}lib"
+// CHECK007:  "-L[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux"
+// CHECK007:  "-L{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}lib"
+// CHECK007:  "-lc++" "-lc++abi"
 
 // -----------------------------------------------------------------------------
 // Checking the invoked linker for elf.
 // Passing -musl, -gnu and -linux
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK007 %s
+// RUN:   | FileCheck -check-prefix=CHECK008 %s
 
 // RUN: %clang -### -target x86_64-pc-linux-gnu %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK007 %s
+// RUN:   | FileCheck -check-prefix=CHECK008 %s
 
 // RUN: %clang -### -target x86_64-pc-linux %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK007 %s
+// RUN:   | FileCheck -check-prefix=CHECK008 %s
 
-// CHECK007:      "{{.*}}ld"
+// CHECK008:      "{{.*}}ld"
 
 // -----------------------------------------------------------------------------
 // Checking the invoked linker for rld.
 // Passing -musl, -gnu and -linux
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK008 %s
+// RUN:   | FileCheck -check-prefix=CHECK009 %s
 
 // RUN: %clang -### -target x86_64-pc-linux-gnu-repo %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK008 %s
+// RUN:   | FileCheck -check-prefix=CHECK009 %s
 
 // RUN: %clang -### -target x86_64-pc-linux-repo %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK008 %s
+// RUN:   | FileCheck -check-prefix=CHECK009 %s
 
-// CHECK008:      "{{.*}}rld"
+// CHECK009:      "{{.*}}rld"

--- a/clang/test/Driver/repo-toolchain-linux-musl.c
+++ b/clang/test/Driver/repo-toolchain-linux-musl.c
@@ -4,34 +4,11 @@
 // -----------------------------------------------------------------------------
 // RUN: %clangxx -### -no-canonical-prefixes -target x86_64-pc-linux-musl-repo -stdlib=libc++ \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-MUSL %s
 
-// CHECK-X86-64-LIBCXX-MUSL: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
 // CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}include"
-
-// -----------------------------------------------------------------------------
-// Checking the header search
-// Passing -gnu -stdlib=libc++
-// -----------------------------------------------------------------------------
-
-// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -stdlib=libc++ \
-// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-GNU %s
-
-// RUN: %clangxx -### -target x86_64-pc-linux-repo -stdlib=libc++ \
-// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-GNU %s
-
-// CHECK-X86-64-LIBCXX-GNU: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK-X86-64-LIBCXX-GNU-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-X86-64-LIBCXX-GNU: "-internal-externc-isystem" "/usr/include"
 
 // -----------------------------------------------------------------------------
 // Checking the header search
@@ -39,38 +16,13 @@
 // -----------------------------------------------------------------------------
 // RUN: %clangxx -### -target x86_64-pc-linux-musl-repo -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:     -resource-dir=%S/Inputs/resource_dir \
 // RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:     %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-SYSROOT-MUSL %s
 
-// CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-isysroot" "[[SYSROOT:[^"]+]]"
 // CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
 // CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
-
-// -----------------------------------------------------------------------------
-// Checking the header search
-// Passing -gnu -stdlib=libc++ --sysroot
-// -----------------------------------------------------------------------------
-// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -stdlib=libc++ \
-// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:     -resource-dir=%S/Inputs/resource_dir \
-// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:     %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-SYSROOT %s
-
-// RUN: %clangxx -### -target x86_64-pc-linux-repo -stdlib=libc++ \
-// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:     -resource-dir=%S/Inputs/resource_dir \
-// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:     %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-SYSROOT %s
-
-// CHECK-X86-64-LIBCXX-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK-X86-64-LIBCXX-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
-// CHECK-X86-64-LIBCXX-SYSROOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}usr{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-X86-64-LIBCXX-SYSROOT: "-internal-externc-isystem" "[[SYSROOT]]{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
 // Checking the header search
@@ -78,30 +30,13 @@
 // -----------------------------------------------------------------------------
 // RUN: %clangxx -### -target x86_64-pc-linux-musl-repo -nostdinc \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:     -resource-dir=%S/Inputs/resource_dir \
 // RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:     %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-NOSTDINC-SYSROOT %s
 
-// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -nostdinc \
-// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:     -resource-dir=%S/Inputs/resource_dir \
-// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:     %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-NOSTDINC-SYSROOT %s
-
-// RUN: %clangxx -### -target x86_64-pc-linux-repo -nostdinc \
-// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:     -resource-dir=%S/Inputs/resource_dir \
-// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:     %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-NOSTDINC-SYSROOT %s
-
-// CHECK-NOSTDINC-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-NOSTDINC-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
 // CHECK-NOSTDINC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-NOSTDINC-SYSROOT-NOT: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
-// CHECK-NOSTDINC-SYSROOT-NOT: "-internal-isystem" "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
+// CHECK-NOSTDINC-SYSROOT-NOT: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
 // Checking the header search
@@ -109,29 +44,12 @@
 // -----------------------------------------------------------------------------
 // RUN: %clangxx -### -target x86_64-pc-linux-musl-repo -nobuiltininc \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:     -resource-dir=%S/Inputs/resource_dir \
 // RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:     %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-NOBUILTININC-SYSROOT %s
 
-// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -nobuiltininc \
-// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:     -resource-dir=%S/Inputs/resource_dir \
-// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:     %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-NOBUILTININC-SYSROOT %s
-
-// RUN: %clangxx -### -target x86_64-pc-linux-repo -nobuiltininc \
-// RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:     -resource-dir=%S/Inputs/resource_dir \
-// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:     %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-NOBUILTININC-SYSROOT %s
-
-// CHECK-NOBUILTININC: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-NOBUILTININC: "-isysroot" "[[SYSROOT:[^"]+]]"
 // CHECK-NOBUILTININC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-NOBUILTININC-SYSROOT-NOT: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-NOBUILTININC-SYSROOT-NOT: "-internal-isystem" "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
@@ -140,26 +58,10 @@
 // -----------------------------------------------------------------------------
 // RUN: %clangxx -### -target x86_64-pc-linux-musl-repo -nostdlibinc \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-NOSTDLIBINC-SYSROOT %s
 
-// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo -nostdlibinc \
-// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-NOSTDLIBINC-SYSROOT %s
-
-// RUN: %clangxx -### -target x86_64-pc-linux-repo -nostdlibinc \
-// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-NOSTDLIBINC-SYSROOT %s
-
-// CHECK-NOSTDLIBINC-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-NOSTDLIBINC-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
 // CHECK-NOSTDLIBINC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
 // CHECK-NOSTDLIBINC-SYSROOT-NOT: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
@@ -171,37 +73,20 @@
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK000 %s
 
-// RUN: %clang -### -target x86_64-pc-linux-gnu-repo %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK000 %s
-
-// RUN: %clang -### -target x86_64-pc-linux-repo %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK000 %s
-
 // CHECK000:      "{{.*}}rld"
 // CHECK000-NOT:  "/usr/local/musl/lib/crti.t"
 // CHECK000:      "/usr/local/musl/lib/crt1.t"
 // CHECK000:      "/usr/local/musl/lib/crt1_asm.t"
+// CHECK000:      "/usr/local/musl/lib/libc_repo.a"
 // CHECK000:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
 // CHECK000:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK000-NOT:  "-lclang_rt.builtins-x86_64" "-lc"
+// CHECK000:      "-lclang_rt.builtins-x86_64"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
-// Passing --musl --sysroot -resource-dir
+// Passing --musl --sysroot
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK001 %s
-
-// RUN: %clang -### -target x86_64-pc-linux-gnu-repo \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK001 %s
-
-// RUN: %clang -### -target x86_64-pc-linux-repo \
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   %s 2>&1 \
@@ -212,9 +97,10 @@
 // CHECK001-NOT:  "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t"
 // CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1.t"
 // CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t"
+// CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}libc_repo.a"
 // CHECK001:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
 // CHECK001:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK001-NOT:  "-lclang_rt.builtins-x86_64" "-lc"
+// CHECK001:      "-lclang_rt.builtins-x86_64"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -224,23 +110,13 @@
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   | FileCheck -check-prefix=CHECK002 %s
 
-// RUN: %clang -### -target x86_64-pc-linux-gnu-repo -nostdlib %s 2>&1 \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   | FileCheck -check-prefix=CHECK002 %s
-
-// RUN: %clang -### -target x86_64-pc-linux-repo -nostdlib %s 2>&1 \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   | FileCheck -check-prefix=CHECK002 %s
-
 // CHECK002:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK002-NOT:   "/usr/local/musl/lib/crti.t"
 // CHECK002-NOT:   "/usr/local/musl/lib/crt1.t"
 // CHECK002-NOT:   "/usr/local/musl/lib/crt1_asm.t"
-// CHECK002-NOT:   "-lclang_rt.builtins-x86_64"
+// CHECK002-NOT:   "/usr/local/musl/lib/libc_repo.a"
 // CHECK002-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
 // CHECK002-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
 // CHECK002-NOT:   "-lclang_rt.builtins-x86_64"
-// CHECK002-NOT:   "-lc"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -252,25 +128,13 @@
 // RUN:   %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK003 %s
 
-// RUN: %clang -### -target x86_64-pc-linux-gnu-repo -nostartfiles \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK003 %s
-
-// RUN: %clang -### -target x86_64-pc-linux-repo -nostartfiles \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK003 %s
-
 // CHECK003:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t
 // CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t
-// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}Scrt1
+// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t
+// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}libc_repo.a"
 // CHECK003-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
 // CHECK003-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK003-NOT:   "-lclang_rt.builtins-x86_64" "-lc"
+// CHECK003:   "-lclang_rt.builtins-x86_64"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -282,25 +146,12 @@
 // RUN:   %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK004 %s
 
-// RUN: %clang -### -target x86_64-pc-linux-gnu-repo -nodefaultlibs \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK004 %s
-
-// RUN: %clang -### -target x86_64-pc-linux-repo -nodefaultlibs \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK004 %s
-
 // CHECK004:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK004:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t
 // CHECK004:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t
 // CHECK004:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
 // CHECK004:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
 // CHECK004-NOT:   -lclang_rt.builtins-x86_64
-// CHECK004-NOT:   -lc
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -333,36 +184,32 @@
 // CHECK006:  "-L{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}lib"
 // CHECK006:  "-lc++" "-lc++abi"
 
-// RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK007 %s
-
-// RUN: %clangxx -### -target x86_64-pc-linux-repo \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK007 %s
-
-// CHECK007:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK007-NOT:  "-L{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}lib"
-// CHECK007-NOT:  "-L[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux"
-// CHECK007-NOT:  "-L{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}lib"
-// CHECK007-NOT:  "-lc++" "-lc++abi"
-// CHECK007: "-lstdc++"
-
 // -----------------------------------------------------------------------------
 // Checking the invoked linker for elf.
-// Passing -musl, -gnu and linux
+// Passing -musl, -gnu and -linux
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK008 %s
+// RUN:   | FileCheck -check-prefix=CHECK007 %s
 
 // RUN: %clang -### -target x86_64-pc-linux-gnu %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK008 %s
+// RUN:   | FileCheck -check-prefix=CHECK007 %s
 
 // RUN: %clang -### -target x86_64-pc-linux %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK007 %s
+
+// CHECK007:      "{{.*}}ld"
+
+// -----------------------------------------------------------------------------
+// Checking the invoked linker for rld.
+// Passing -musl, -gnu and -linux
+// -----------------------------------------------------------------------------
+// RUN: %clang -### -target x86_64-pc-linux-musl-repo %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK008 %s
 
-// CHECK008:      "{{.*}}ld"
+// RUN: %clang -### -target x86_64-pc-linux-gnu-repo %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK008 %s
+
+// RUN: %clang -### -target x86_64-pc-linux-repo %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK008 %s
+
+// CHECK008:      "{{.*}}rld"

--- a/clang/test/Driver/repo-toolchain-linux-musl.c
+++ b/clang/test/Driver/repo-toolchain-linux-musl.c
@@ -91,83 +91,21 @@
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
-// Passing --musl -static
-// -----------------------------------------------------------------------------
-// RUN: %clang -### -target x86_64-pc-linux-musl-repo -static %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK001 %s
-// CHECK001-NOT:  "/usr/local/musl/lib/crti.t.o"
-// CHECK001:      "/usr/local/musl/lib/crt1.t.o"
-// CHECK001:      "/usr/local/musl/lib/crt1_asm.t.o"
-// CHECK001:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK001:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK001:      "-lclang_rt.builtins-x86_64" "-lc"
-
-// -----------------------------------------------------------------------------
-// Checking the linked objects and libraries
-// Passing --musl -shared
-// -----------------------------------------------------------------------------
-// RUN: %clang -### -target x86_64-pc-linux-musl-repo -shared %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK002 %s
-// CHECK002-NOT:   "/usr/local/musl/lib/crt1.t.o"
-// CHECK002-NOT:   "/usr/local/musl/lib/crt1_asm.t.o"
-// CHECK002:       "/usr/local/musl/lib/crti.t.o"
-// CHECK002:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK002:      "{{.*}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK002:       "-lclang_rt.builtins-x86_64" "-lc"
-
-// -----------------------------------------------------------------------------
-// Checking the linked objects and libraries
 // Passing --musl --sysroot -resource-dir
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo \
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK003 %s
-// CHECK003:      "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK003:      "-isysroot" "[[SYSROOT:[^"]+]]"
-// CHECK003-NOT:  "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t.o"
-// CHECK003:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1.t.o"
-// CHECK003:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o"
-// CHECK003:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK003:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK003:      "-lclang_rt.builtins-x86_64" "-lc"
-
-// -----------------------------------------------------------------------------
-// Checking the linked objects and libraries
-// Passing --musl -static --sysroot
-// -----------------------------------------------------------------------------
-// RUN: %clang -### -target x86_64-pc-linux-musl-repo -static \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK004 %s
-// CHECK004:      "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK004:      "-isysroot" "[[SYSROOT:[^"]+]]"
-// CHECK004-NOT:  "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t.o"
-// CHECK004:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1.t.o"
-// CHECK004:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o"
-// CHECK004:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK004:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK004:      "-lclang_rt.builtins-x86_64" "-lc"
-
-// -----------------------------------------------------------------------------
-// Checking the linked objects and libraries
-// Passing --musl -shared --sysroot
-// -----------------------------------------------------------------------------
-// RUN: %clang -### -target x86_64-pc-linux-musl-repo -shared \
-// RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
-// RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK005 %s
-// CHECK005:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK005:       "-isysroot" "[[SYSROOT:[^"]+]]"
-// CHECK005-NOT:   "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1.t.o"
-// CHECK005-NOT:   "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o"
-// CHECK005:       "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t.o"
-// CHECK005:       "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK005:       "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK005:       "-lclang_rt.builtins-x86_64" "-lc"
+// RUN:   | FileCheck -check-prefix=CHECK001 %s
+// CHECK001:      "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK001:      "-isysroot" "[[SYSROOT:[^"]+]]"
+// CHECK001-NOT:  "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crti.t.o"
+// CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1.t.o"
+// CHECK001:      "[[SYSROOT]]{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o"
+// CHECK001:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK001:      "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK001:      "-lclang_rt.builtins-x86_64" "-lc"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -175,16 +113,16 @@
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo -nostdlib %s 2>&1 \
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
-// RUN:   | FileCheck -check-prefix=CHECK006 %s
-// CHECK006:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK006-NOT:   "/usr/local/musl/lib/crti.t.o"
-// CHECK006-NOT:   "/usr/local/musl/lib/crt1.t.o"
-// CHECK006-NOT:   "/usr/local/musl/lib/crt1_asm.t.o"
-// CHECK006-NOT:   "-lclang_rt.builtins-x86_64"
-// CHECK006-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK006-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK006-NOT:   "-lclang_rt.builtins-x86_64"
-// CHECK006-NOT:   "-lc"
+// RUN:   | FileCheck -check-prefix=CHECK002 %s
+// CHECK002:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK002-NOT:   "/usr/local/musl/lib/crti.t.o"
+// CHECK002-NOT:   "/usr/local/musl/lib/crt1.t.o"
+// CHECK002-NOT:   "/usr/local/musl/lib/crt1_asm.t.o"
+// CHECK002-NOT:   "-lclang_rt.builtins-x86_64"
+// CHECK002-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK002-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK002-NOT:   "-lclang_rt.builtins-x86_64"
+// CHECK002-NOT:   "-lc"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -194,14 +132,14 @@
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK007 %s
-// CHECK007:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK007-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o
-// CHECK007-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t.o
-// CHECK007-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}Scrt1.o
-// CHECK007-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK007-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK007:       "-lclang_rt.builtins-x86_64" "-lc"
+// RUN:   | FileCheck -check-prefix=CHECK003 %s
+// CHECK003:       "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o
+// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t.o
+// CHECK003-NOT:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}Scrt1.o
+// CHECK003-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK003-NOT:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK003:       "-lclang_rt.builtins-x86_64" "-lc"
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -211,22 +149,22 @@
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK008 %s
-// CHECK008:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK008:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t.o
-// CHECK008:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o
-// CHECK008:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
-// CHECK008:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
-// CHECK008-NOT:   -lclang_rt.builtins-x86_64
-// CHECK008-NOT:   -lc
+// RUN:   | FileCheck -check-prefix=CHECK004 %s
+// CHECK004:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK004:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1.t.o
+// CHECK004:   {{.*}}basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}crt1_asm.t.o
+// CHECK004:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtbegin-x86_64.o"
+// CHECK004:   "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux{{/|\\\\}}clang_rt.crtend-x86_64.o"
+// CHECK004-NOT:   -lclang_rt.builtins-x86_64
+// CHECK004-NOT:   -lc
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
 // Not Passing -fno-use-init-array when musl is selected
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl-repo %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK009 %s
-// CHECK009-NOT:          -fno-use-init-array
+// RUN:   | FileCheck -check-prefix=CHECK005 %s
+// CHECK005-NOT:          -fno-use-init-array
 
 // -----------------------------------------------------------------------------
 // Checking the linked objects and libraries
@@ -236,9 +174,9 @@
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
 // RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK010 %s
-// CHECK010:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK010:  "-L{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}lib"
-// CHECK010:  "-L[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux"
-// CHECK010:  "-L{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}lib"
-// CHECK010:  "-lc++" "-lc++abi" "-lunwind"
+// RUN:   | FileCheck -check-prefix=CHECK006 %s
+// CHECK006:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK006:  "-L{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}lib"
+// CHECK006:  "-L[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux"
+// CHECK006:  "-L{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}lib"
+// CHECK006:  "-lc++" "-lc++abi" "-lunwind"

--- a/clang/test/Driver/repo-toolchain-linux-musl.c
+++ b/clang/test/Driver/repo-toolchain-linux-musl.c
@@ -9,9 +9,8 @@
 // RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-MUSL %s
 
 // CHECK-X86-64-LIBCXX-MUSL: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
-// CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}include"
 // CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
 // Checking the header search
@@ -31,9 +30,8 @@
 // RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-GNU %s
 
 // CHECK-X86-64-LIBCXX-GNU: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK-X86-64-LIBCXX-GNU: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
-// CHECK-X86-64-LIBCXX-GNU: "-internal-externc-isystem" "/usr/include"
 // CHECK-X86-64-LIBCXX-GNU-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-X86-64-LIBCXX-GNU: "-internal-externc-isystem" "/usr/include"
 
 // -----------------------------------------------------------------------------
 // Checking the header search
@@ -48,9 +46,8 @@
 
 // CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-isysroot" "[[SYSROOT:[^"]+]]"
-// CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
-// CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
 // CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
 // Checking the header search
@@ -73,7 +70,6 @@
 // CHECK-X86-64-LIBCXX-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-X86-64-LIBCXX-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
 // CHECK-X86-64-LIBCXX-SYSROOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}usr{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-X86-64-LIBCXX-SYSROOT: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
 // CHECK-X86-64-LIBCXX-SYSROOT: "-internal-externc-isystem" "[[SYSROOT]]{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
@@ -166,7 +162,6 @@
 // CHECK-NOSTDLIBINC-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-NOSTDLIBINC-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
 // CHECK-NOSTDLIBINC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-NOSTDLIBINC-SYSROOT: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-NOSTDLIBINC-SYSROOT-NOT: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
@@ -332,35 +327,42 @@
 // RUN:   %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK006 %s
 
+// CHECK006:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK006:  "-L{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}lib"
+// CHECK006:  "-L[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux"
+// CHECK006:  "-L{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}lib"
+// CHECK006:  "-lc++" "-lc++abi"
+
 // RUN: %clangxx -### -target x86_64-pc-linux-gnu-repo \
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
 // RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK006 %s
+// RUN:   | FileCheck -check-prefix=CHECK007 %s
 
 // RUN: %clangxx -### -target x86_64-pc-linux-repo \
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/bin \
 // RUN:   %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK006 %s
+// RUN:   | FileCheck -check-prefix=CHECK007 %s
 
-// CHECK006:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK006-NOT:  "-L{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}lib"
-// CHECK006-NOT:  "-L[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux"
-// CHECK006-NOT:  "-L{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}lib"
-// CHECK006-NOT:  "-lc++" "-lc++abi" "-lunwind"
+// CHECK007:   "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK007-NOT:  "-L{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}lib"
+// CHECK007-NOT:  "-L[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}linux"
+// CHECK007-NOT:  "-L{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}lib"
+// CHECK007-NOT:  "-lc++" "-lc++abi"
+// CHECK007: "-lstdc++"
 
 // -----------------------------------------------------------------------------
 // Checking the invoked linker for elf.
 // Passing -musl, -gnu and linux
 // -----------------------------------------------------------------------------
 // RUN: %clang -### -target x86_64-pc-linux-musl %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK007 %s
+// RUN:   | FileCheck -check-prefix=CHECK008 %s
 
 // RUN: %clang -### -target x86_64-pc-linux-gnu %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK007 %s
+// RUN:   | FileCheck -check-prefix=CHECK008 %s
 
 // RUN: %clang -### -target x86_64-pc-linux %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK007 %s
+// RUN:   | FileCheck -check-prefix=CHECK008 %s
 
-// CHECK007:      "{{.*}}ld"
+// CHECK008:      "{{.*}}ld"

--- a/llvm/test/Feature/Repo/repo_rename_GOs_runtime_test.c
+++ b/llvm/test/Feature/Repo/repo_rename_GOs_runtime_test.c
@@ -8,7 +8,7 @@
 // RUN: env REPOFILE=%t.db repo2obj %t1.o --repo %t.db -o %t1.elf.o
 // RUN: env REPOFILE=%t.db clang -c -o -O3 -target x86_64-pc-linux-gnu-repo %s -o %t2.o
 // RUN: env REPOFILE=%t.db repo2obj %t2.o --repo %t.db -o %t2.elf.o
-// RUN: clang -o %t.out -O3 -target x86_64-pc-linux-gnu-repo %t.elf.o %t1.elf.o %t2.elf.o
+// RUN: clang -o %t.out -O3 -target x86_64-pc-linux-gnu-elf %t.elf.o %t1.elf.o %t2.elf.o
 // RUN: %t.out | FileCheck %s
 
 extern void func1(void);


### PR DESCRIPTION
After this change, the repo toolchain will be only used when targeting on the x86_64-pc-linux-musl-repo target.