### PR TITLE
Add link++.py to wrap links of C++ programs.

### DIFF
--- a/llvm/utils/repo/docker/llvm-prepo/Dockerfile
+++ b/llvm/utils/repo/docker/llvm-prepo/Dockerfile
@@ -92,6 +92,7 @@ RUN rm -rf /var/lib/apt/lists/*
 
 COPY repo/archive.py /usr/share/repo/
 COPY repo/link.py /usr/share/repo/
+COPY repo/link++.py /usr/share/repo/
 COPY repo/repo.cmake /usr/share/repo/
 COPY repo/repo.json /usr/share/repo/
 COPY repo/wrap_tool.py /usr/share/repo/

--- a/llvm/utils/repo/link++.py
+++ b/llvm/utils/repo/link++.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# ===- link.py - ---------------------------------------------*- python -*--===#
+# ===- link++.py - -------------------------------------------*- python -*--===#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
@@ -19,10 +19,11 @@ import wrap_tool
 def main (argv):
     try:
         logging.basicConfig ()
-        return wrap_tool.wrap_tool (tool='link', argv=['-target','x86_64-pc-linux-gnu-elf'] + argv[1:])
+        return wrap_tool.wrap_tool (tool='link++', argv=['-target','x86_64-pc-linux-gnu-elf']+argv[1:])
     except subprocess.CalledProcessError:
         return 1
 
 if __name__ == '__main__':
     sys.exit (main (sys.argv))
-# eof: link.py
+
+# eof: link++.py

--- a/llvm/utils/repo/link++.py
+++ b/llvm/utils/repo/link++.py
@@ -19,7 +19,7 @@ import wrap_tool
 def main (argv):
     try:
         logging.basicConfig ()
-        return wrap_tool.wrap_tool (tool='link++', argv=['-target','x86_64-pc-linux-gnu-elf']+argv[1:])
+        return wrap_tool.wrap_tool (tool='link++', argv=['-target','x86_64-pc-linux-gnu']+argv[1:])
     except subprocess.CalledProcessError:
         return 1
 

--- a/llvm/utils/repo/link.py
+++ b/llvm/utils/repo/link.py
@@ -19,7 +19,7 @@ import wrap_tool
 def main (argv):
     try:
         logging.basicConfig ()
-        return wrap_tool.wrap_tool (tool='link', argv=['-target','x86_64-pc-linux-gnu-elf'] + argv[1:])
+        return wrap_tool.wrap_tool (tool='link', argv=['-target','x86_64-pc-linux-gnu'] + argv[1:])
     except subprocess.CalledProcessError:
         return 1
 

--- a/llvm/utils/repo/repo.json
+++ b/llvm/utils/repo/repo.json
@@ -1,5 +1,6 @@
 {
   "ar": "/usr/bin/ar",
-  "link": "/usr/bin/clang++",
+  "link": "/usr/bin/clang",
+  "link++": "/usr/bin/clang++",
   "repo2obj": "/usr/bin/repo2obj"
 }

--- a/llvm/utils/repo/wrap_tool.py
+++ b/llvm/utils/repo/wrap_tool.py
@@ -133,7 +133,7 @@ def _open_config_file(name='repo.json'):
     def try_path(p):
         try:
             fp = open (p)
-            _logger.debug('configuration file "%s" was found at "%s"', name, path)
+            _logger.info('configuration file "%s" was found at "%s"', name, path)
             return fp
         except:
             return None


### PR DESCRIPTION
Previously, the link tool would run clang++. This was mostly okay, but linked additional libraries that may not be available on the host. Explicitly set the target file format to ELF for linking.