### PR TITLE
Use the clang and musl include dirs when building libcxx.

### DIFF
--- a/llvm/utils/repo/docker/llvm-prepo/Dockerfile
+++ b/llvm/utils/repo/docker/llvm-prepo/Dockerfile
@@ -183,15 +183,18 @@ RUN REPOFILE=$stdlib_repo ninja -C $libbuild_dir/compiler-rt install
 # libcxxabi #
 #############
 
-RUN REPOFILE=$configure_repo cmake                                     \
-  -S $workspace_dir/src/libcxxabi                                      \
-  -B $libbuild_dir/cxxabi                                              \
-  -D libcxxabi_include=-I$workspace_dir/build/lib/clang/11.0.0/include \
-  -D LIBCXXABI_ENABLE_EXCEPTIONS=No                                    \
-  -D LIBCXXABI_USE_COMPILER_RT=Yes                                     \
-  -D LIBCXXABI_ENABLE_SHARED=No                                        \
-  -D LIBCXXABI_ENABLE_STATIC=Yes                                       \
-  -D LLVM_ENABLE_LIBCXX=Yes                                            \
+# Path of the clang-specific header files
+ARG clang_include=$workspace_dir/build/lib/clang/11.0.0/include
+
+RUN REPOFILE=$configure_repo cmake      \
+  -S $workspace_dir/src/libcxxabi       \
+  -B $libbuild_dir/cxxabi               \
+  -D libcxxabi_include=-I$clang_include \
+  -D LIBCXXABI_ENABLE_EXCEPTIONS=No     \
+  -D LIBCXXABI_USE_COMPILER_RT=Yes      \
+  -D LIBCXXABI_ENABLE_SHARED=No         \
+  -D LIBCXXABI_ENABLE_STATIC=Yes        \
+  -D LLVM_ENABLE_LIBCXX=Yes             \
   $cmake_common
 
 # TODO: the check-cxxabi stage is missing.
@@ -205,11 +208,13 @@ RUN REPOFILE=$stdlib_repo ninja -C $libbuild_dir/cxxabi cxxabi install-cxxabi
 RUN REPOFILE=$configure_repo cmake                                     \
   -S $workspace_dir/src/libcxx                                         \
   -B $libbuild_dir/cxx                                                 \
-  -D LIBCXX_ENABLE_SHARED=No                                           \
-  -D LIBCXX_ENABLE_STATIC=Yes                                          \
+  -D CMAKE_CXX_FLAGS="-isystem $clang_include -isystem $musl_install_dir/include" \
   -D LIBCXX_CXX_ABI=libcxxabi                                          \
   -D LIBCXX_CXX_ABI_INCLUDE_PATHS=$workspace_dir/src/libcxxabi/include \
+  -D LIBCXX_ENABLE_SHARED=No                                           \
+  -D LIBCXX_ENABLE_STATIC=Yes                                          \
   -D LIBCXX_HAS_MUSL_LIBC=Yes                                          \
+  -D LIBCXX_INCLUDE_BENCHMARKS=No                                      \
   $cmake_common
 
 # TODO: the check-cxx stage is missing.

--- a/rld/lib/Context.cpp
+++ b/rld/lib/Context.cpp
@@ -71,12 +71,13 @@ void rld::Context::MmapDeleter::operator()(std::uint8_t *P) const {
 
 // record compilation
 // ~~~~~~~~~~~~~~~~~~
-pstore::repo::compilation const &rld::Context::recordCompilation(
+const pstore::repo::compilation &rld::Context::recordCompilation(
     pstore::extent<pstore::repo::compilation> const &CompilationExtent) {
-  std::lock_guard<std::mutex> Lock{CompilationsMut_};
-  Compilations_.emplace_back(
-      pstore::repo::compilation::load(this->Db, CompilationExtent));
-  return *Compilations_.back();
+
+  auto Compilation =
+      pstore::repo::compilation::load(this->Db, CompilationExtent);
+  std::lock_guard<decltype(CompilationsMut_)> _{CompilationsMut_};
+  return *Compilations_.emplace_back(std::move(Compilation));
 }
 
 // create shadow memory

--- a/rld/lib/ELFOutput.cpp
+++ b/rld/lib/ELFOutput.cpp
@@ -333,7 +333,7 @@ rld::elfOutput(const llvm::StringRef &OutputFileName, Context &Context,
     });
   }
 
-  MPMCQueue<WorkItem> Q{std::size_t{1024}};
+  MPMCQueue<WorkItem> Q{std::size_t{32768}};
 
   assert(llvm::llvm_is_multithreaded());
   const auto NumConsumers = std::max(WorkPool.getThreadCount(), 1U);

--- a/rld/lib/Scanner.cpp
+++ b/rld/lib/Scanner.cpp
@@ -39,13 +39,6 @@ namespace {
 
 constexpr auto DebugType = "rld-scanner";
 
-#if 0
-    llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
-                                  pstore::index::digest const &Digest) {
-      return OS << Digest.to_hex_string();
-    }
-#endif
-
 } // end anonymous namespace
 
 static std::string timerName(const bool Enabled, const uint32_t InputOrdinal) {

--- a/rld/unit_tests/rld/TestSymbolResolver.cpp
+++ b/rld/unit_tests/rld/TestSymbolResolver.cpp
@@ -53,9 +53,9 @@ public:
 protected:
   rld::StringAddress getStringAddress(char const *Name);
 
-  static void checkFragmentContents(
-      std::shared_ptr<pstore::repo::fragment const> const &Fragment,
-      uint8_t Index, pstore::repo::linkage Linkage);
+  static void checkFragmentContents(rld::FragmentPtr const &Fragment,
+                                    uint8_t Index,
+                                    pstore::repo::linkage Linkage);
 
   /// A function which will create a compilation containing a single definition
   /// with a particular name and linkage. There's unavoidable logic here because
@@ -91,9 +91,9 @@ SymbolScanner::compile(std::string const &DefinitionName,
 
 // check fragment contents [static]
 // ~~~~~~~~~~~~~~~~~~~~~~~
-void SymbolScanner::checkFragmentContents(
-    std::shared_ptr<pstore::repo::fragment const> const &Fragment,
-    uint8_t Index, pstore::repo::linkage Linkage) {
+void SymbolScanner::checkFragmentContents(rld::FragmentPtr const &Fragment,
+                                          uint8_t Index,
+                                          pstore::repo::linkage Linkage) {
   ASSERT_NE(Fragment.get(), nullptr);
   EXPECT_EQ(Fragment->size(), 1U);
   if (Linkage == pstore::repo::linkage::common) {


### PR DESCRIPTION
Set CMAKE_CXX_FLAGS explicitly when running cmake for libcxx so that we include both the clang and musl include directories. A separate switch already handles the libcxxabi includes. Explicitly disable the libcxx benchmarks: they're not necessary for the docker image. Factor out repeated use of the clang include path as $clang_include.

Some rld changes seem to have become mixed up in this code review. I don't know why :-(. Please ignore them.