### PR TITLE
Prioritize /usr/include/c++/v1 over RESOURCE_DIR/include on musl-repo.

### DIFF
--- a/clang/lib/Driver/ToolChains/Repo.cpp
+++ b/clang/lib/Driver/ToolChains/Repo.cpp
@@ -162,16 +162,6 @@ void RepoMuslToolChain::AddClangSystemIncludeArgs(
 
   const Driver &D = getDriver();
 
-  // Add the Clang builtin headers (<resource>/include).
-  if (!DriverArgs.hasArg(options::OPT_nobuiltininc)) {
-    llvm::SmallString<128> P = llvm::StringRef(D.ResourceDir);
-    llvm::sys::path::append(P, "/include");
-    addSystemInclude(DriverArgs, CC1Args, P);
-  }
-
-  if (DriverArgs.hasArg(options::OPT_nostdlibinc))
-    return;
-
   if (!DriverArgs.hasArg(options::OPT_nostdinc) &&
       !DriverArgs.hasArg(options::OPT_nostdlibinc) &&
       !DriverArgs.hasArg(options::OPT_nobuiltininc) &&
@@ -183,7 +173,16 @@ void RepoMuslToolChain::AddClangSystemIncludeArgs(
     addSystemInclude(DriverArgs, CC1Args, P);
   }
 
+  // Add the Clang builtin headers (<resource>/include).
   if (!DriverArgs.hasArg(options::OPT_nobuiltininc)) {
+    llvm::SmallString<128> P = llvm::StringRef(D.ResourceDir);
+    llvm::sys::path::append(P, "/include");
+    addSystemInclude(DriverArgs, CC1Args, P);
+  }
+
+  // Add the musl headers (musl/include).
+  if (!DriverArgs.hasArg(options::OPT_nobuiltininc) &&
+      !DriverArgs.hasArg(options::OPT_nostdlibinc)) {
     if (!D.SysRoot.empty()) {
       SmallString<128> P(D.SysRoot);
       llvm::sys::path::append(P, "/musl/include");

--- a/clang/test/Driver/repo-toolchain-linux-musl.c
+++ b/clang/test/Driver/repo-toolchain-linux-musl.c
@@ -9,8 +9,8 @@
 // RUN:   | FileCheck --check-prefix=CHECK-X86-64-LIBCXX-MUSL %s
 
 // CHECK-X86-64-LIBCXX-MUSL: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-// CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-X86-64-LIBCXX-MUSL: "-internal-isystem" "{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}musl{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
@@ -26,8 +26,8 @@
 
 // CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-isysroot" "[[SYSROOT:[^"]+]]"
-// CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-X86-64-LIBCXX-SYSROOT-MUSL: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}musl{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
@@ -43,8 +43,8 @@
 
 // CHECK-NOSTDINC-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-NOSTDINC-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
-// CHECK-NOSTDINC-SYSROOT-NOT: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-NOSTDINC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-NOSTDINC-SYSROOT-NOT: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-NOSTDINC-SYSROOT-NOT: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}musl{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
@@ -60,8 +60,8 @@
 
 // CHECK-NOBUILTININC: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-NOBUILTININC: "-isysroot" "[[SYSROOT:[^"]+]]"
-// CHECK-NOBUILTININC-SYSROOT-NOT: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-NOBUILTININC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-NOBUILTININC-SYSROOT-NOT: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-NOBUILTININC-SYSROOT-NOT: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}musl{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
@@ -77,8 +77,8 @@
 
 // CHECK-NOSTDLIBINC-SYSROOT: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 // CHECK-NOSTDLIBINC-SYSROOT: "-isysroot" "[[SYSROOT:[^"]+]]"
-// CHECK-NOSTDLIBINC-SYSROOT: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-NOSTDLIBINC-SYSROOT-NOT: "-internal-isystem" "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-NOSTDLIBINC-SYSROOT: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-NOSTDLIBINC-SYSROOT-NOT: "-internal-isystem" "[[SYSROOT]]{{/|\\\\}}musl{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
When building clang project, we get the following error:

`
  /usr/bin/../include/c++/v1/cstddef:53:9: error: no member named 'max_align_t' in the global namespace
  using ::max_align_t;
        ~~^
`

Reorder RESOURCE_DIR/include to fix the search order problem.
