### PR TITLE
Create DebugLocSection as a dummy section.

### DIFF
--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -305,6 +305,7 @@ namespace llvm {
       ReadOnlySection,
       ReadOnlyWithRelSection,
       DebugLine,
+      DebugLoc,
       DebugString,
       DebugRanges,
     };

--- a/llvm/include/llvm/MC/MCSectionRepo.h
+++ b/llvm/include/llvm/MC/MCSectionRepo.h
@@ -24,6 +24,7 @@ public:
   enum class DebugSectionKind {
     None,
     Line,
+    Loc,
     Ranges,
     String,
   };

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -659,6 +659,10 @@ MCContext::getRepoSection(RepoSection K, StringRef Name,
     Kind = SectionKind::getMetadata();
     DebugKind = MCSectionRepo::DebugSectionKind::Ranges;
     break;
+  case RepoSection::DebugLoc:
+    Kind = SectionKind::getMetadata();
+    DebugKind = MCSectionRepo::DebugSectionKind::Loc;
+    break;
   }
 
   auto Result =

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -310,6 +310,8 @@ void MCObjectFileInfo::initRepoMCObjectFileInfo(const Triple &T) {
       Ctx->getRepoSection(MCContext::RepoSection::DebugString)->markAsDummy();
   DwarfRangesSection =
       Ctx->getRepoSection(MCContext::RepoSection::DebugRanges)->markAsDummy();
+  DwarfLocSection =
+      Ctx->getRepoSection(MCContext::RepoSection::DebugLoc)->markAsDummy();
   DwarfLineSection = Ctx->getRepoSection(MCContext::RepoSection::DebugLine);
 
   BSSSection = nullptr;

--- a/llvm/lib/MC/RepoObjectWriter.cpp
+++ b/llvm/lib/MC/RepoObjectWriter.cpp
@@ -409,6 +409,8 @@ sectionKindToRepoType(MCSectionRepo const &Section) {
       return pstore::repo::section_kind::debug_string;
     case MCSectionRepo::DebugSectionKind::Ranges:
       return pstore::repo::section_kind::debug_ranges;
+    case MCSectionRepo::DebugSectionKind::Loc:
+      return pstore::repo::section_kind::debug_loc;
     }
   }
   llvm_unreachable("Unsupported section type in getRepoSection");

--- a/llvm/test/Feature/Repo/repo_debug_loc_crash.cpp
+++ b/llvm/test/Feature/Repo/repo_debug_loc_crash.cpp
@@ -1,0 +1,13 @@
+// This test checks for a crash.  See issue#175.
+// RUN: rm -f %t.db
+// RUN: env REPOFILE=%t.db clang -c -g -O2 -target x86_64-pc-linux-musl-repo %s -o %t
+
+struct a {
+  virtual void b();
+};
+class c {
+public:
+  c(int);
+};
+int d;
+void e(a) { c f(d); }

--- a/llvm/tools/repo2obj/R2OELFSectionType.h
+++ b/llvm/tools/repo2obj/R2OELFSectionType.h
@@ -14,6 +14,7 @@
   X(bss)                                                                       \
   X(data)                                                                      \
   X(debug_line)                                                                \
+  X(debug_loc)                                                                 \
   X(debug_ranges)                                                              \
   X(debug_string)                                                              \
   X(fini_array)                                                                \

--- a/llvm/tools/repo2obj/R2OELFSymbolTable.h
+++ b/llvm/tools/repo2obj/R2OELFSymbolTable.h
@@ -221,6 +221,7 @@ unsigned SymbolTable<ELFT>::sectionToSymbolType(ELFSectionType T) {
   case ELFSectionType::thread_data:
     return llvm::ELF::STT_TLS;
   case ELFSectionType::debug_line:
+  case ELFSectionType::debug_loc:
   case ELFSectionType::debug_ranges:
   case ELFSectionType::debug_string:
   case ELFSectionType::interp:

--- a/llvm/tools/repo2obj/repo2obj.cpp
+++ b/llvm/tools/repo2obj/repo2obj.cpp
@@ -352,6 +352,7 @@ getELFSectionType(pstore::repo::section_kind Kind,
     REPO_TO_ELF_SECTION(bss)
     REPO_TO_ELF_SECTION(data)
     REPO_TO_ELF_SECTION(debug_line)
+    REPO_TO_ELF_SECTION(debug_loc)
     REPO_TO_ELF_SECTION(debug_ranges)
     REPO_TO_ELF_SECTION(debug_string)
     REPO_TO_ELF_SECTION(mergeable_1_byte_c_string)
@@ -396,6 +397,7 @@ shouldCreateSubsection(bool IsLinkOnce,
   case pstore::repo::section_kind::debug_line:
   case pstore::repo::section_kind::debug_string:
   case pstore::repo::section_kind::debug_ranges:
+  case pstore::repo::section_kind::debug_loc:
     // Don't split the debug sections into subsections.
     return false;
 

--- a/rld/include/rld/LayoutBuilder.h
+++ b/rld/include/rld/LayoutBuilder.h
@@ -129,6 +129,7 @@ inline SegmentKind operator++(SegmentKind &SK, int) noexcept {
   RLD_X(SectionKind::bss)                                                      \
                                                                                \
   RLD_X(SectionKind::debug_line)                                               \
+  RLD_X(SectionKind::debug_loc)                                                \
   RLD_X(SectionKind::debug_string)                                             \
   RLD_X(SectionKind::debug_ranges)                                             \
   RLD_X(SectionKind::linked_definitions)                                       \

--- a/rld/lib/ELFSectionHeaders.cpp
+++ b/rld/lib/ELFSectionHeaders.cpp
@@ -51,6 +51,7 @@ static constexpr auto elfSectionType(const SectionKind Kind) {
   switch (Kind) {
   case SectionKind::data:
   case SectionKind::debug_line:
+  case SectionKind::debug_loc:
   case SectionKind::debug_ranges:
   case SectionKind::debug_string:
   case SectionKind::mergeable_1_byte_c_string:
@@ -133,6 +134,7 @@ static constexpr auto elfSectionFlags(const SectionKind Kind) {
     return Elf_Word{llvm::ELF::SHF_ALLOC};
 
   case SectionKind::debug_line:
+  case SectionKind::debug_loc:
   case SectionKind::debug_string:
   case SectionKind::debug_ranges:
   case SectionKind::strtab:
@@ -179,6 +181,7 @@ static constexpr auto elfSectionEntSize(const SectionKind Kind) {
   case SectionKind::bss:
   case SectionKind::data:
   case SectionKind::debug_line:
+  case SectionKind::debug_loc:
   case SectionKind::debug_ranges:
   case SectionKind::debug_string:
   case SectionKind::linked_definitions:

--- a/rld/lib/ELFSectionNames.cpp
+++ b/rld/lib/ELFSectionNames.cpp
@@ -28,6 +28,7 @@ using namespace rld;
   ELF_SECTION_NAME(bss, ".bss")                                                \
   ELF_SECTION_NAME(data, ".data")                                              \
   ELF_SECTION_NAME(debug_line, ".debug_line")                                  \
+  ELF_SECTION_NAME(debug_loc, ".debug_loc")                                    \
   ELF_SECTION_NAME(debug_ranges, ".debug_ranges")                              \
   ELF_SECTION_NAME(debug_string, ".debug_str")                                 \
   ELF_SECTION_NAME(linked_definitions, "")                                     \

--- a/rld/lib/ELFSymbolTable.cpp
+++ b/rld/lib/ELFSymbolTable.cpp
@@ -73,6 +73,7 @@ static constexpr unsigned char sectionToSymbolType(const SectionKind K) {
   case SectionKind::thread_data:
     return llvm::ELF::STT_TLS;
   case SectionKind::debug_line:
+  case SectionKind::debug_loc:
   case SectionKind::debug_ranges:
   case SectionKind::debug_string:
     return llvm::ELF::STT_NOTYPE;

--- a/rld/lib/LayoutBuilder.cpp
+++ b/rld/lib/LayoutBuilder.cpp
@@ -53,6 +53,7 @@ static constexpr bool hasFileData(pstore::repo::section_kind Kind) {
   case section_kind::read_only:
   case section_kind::thread_data:
   case section_kind::debug_line:
+  case section_kind::debug_loc:
   case section_kind::debug_string:
   case section_kind::debug_ranges:
     return true;
@@ -229,6 +230,7 @@ LayoutBuilder::SectionToSegmentArray const LayoutBuilder::SectionToSegment_{{
     {SectionKind::thread_data, SegmentKind::tls},
     {SectionKind::thread_bss, SegmentKind::tls},
     {SectionKind::debug_line, SegmentKind::discard},
+    {SectionKind::debug_loc, SegmentKind::discard},
     {SectionKind::debug_string, SegmentKind::discard},
     {SectionKind::debug_ranges, SegmentKind::discard},
     {SectionKind::linked_definitions, SegmentKind::discard},


### PR DESCRIPTION
Create DebugLocSection as a dummy section which enable the assembler to have a "default" section to avoid an assertion failure.

Fix for https://github.com/SNSystems/llvm-project-prepo/issues/175.

This commit needs to be worked with the pstore changes, which is under the code review https://github.com/SNSystems/pstore/pull/111.